### PR TITLE
Update to Gradle 4.10.3, because of Tooling Api Errors

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip


### PR DESCRIPTION
Keeps throwing for me now. Updating shouldn't change anything at all