### PR TITLE
Add logging markers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,19 +13,15 @@ group = project.group
 // compile for java 8
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
-<<<<<<< HEAD
-// set access widener
-loom.accessWidenerPath = file('src/main/resources/tasmod.accesswidener')
-=======
 loom {
+	// set access widener
 	accessWidenerPath = file('src/main/resources/tasmod.accesswidener')
+	// add log4jconfig
 	log4jConfigs.from(file('src/main/resources/log4j.xml'))
 	
-	mixin {
-		defaultRefmapName = "tasmod.refmap.json"
-	}
+	// default refmap name
+	mixin.defaultRefmapName = "tasmod.refmap.json"
 }
->>>>>>> 7f37d08 (Added custom log4j config)
 
 // dependency repositories
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,19 @@ group = project.group
 // compile for java 8
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
+<<<<<<< HEAD
 // set access widener
 loom.accessWidenerPath = file('src/main/resources/tasmod.accesswidener')
+=======
+loom {
+	accessWidenerPath = file('src/main/resources/tasmod.accesswidener')
+	log4jConfigs.from(file('src/main/resources/log4j.xml'))
+	
+	mixin {
+		defaultRefmapName = "tasmod.refmap.json"
+	}
+}
+>>>>>>> 7f37d08 (Added custom log4j config)
 
 // dependency repositories
 repositories {

--- a/src/main/java/com/minecrafttas/common/Configuration.java
+++ b/src/main/java/com/minecrafttas/common/Configuration.java
@@ -48,7 +48,7 @@ public class Configuration {
 			e.printStackTrace();
 			return null;
 		} catch (FileNotFoundException e) {
-			e.printStackTrace();
+			System.out.println("No config file found: "+file);
 			return null;
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/src/main/java/com/minecrafttas/tasmod/Config.java
+++ b/src/main/java/com/minecrafttas/tasmod/Config.java
@@ -1,5 +1,0 @@
-package com.minecrafttas.tasmod;
-
-
-public class Config {
-}

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 
 import com.minecrafttas.common.CommandRegistry;
 import com.minecrafttas.common.events.EventListener;
@@ -69,7 +71,7 @@ public class TASmod implements ModInitializer, EventServerInit, EventServerStop{
 
 	private static MinecraftServer serverInstance;
 	
-	public static final Logger logger = LogManager.getLogger("TASMod");
+	public static final Logger logger = LogManager.getLogger("TASmod");
 	
 	public static TASstateServer containerStateServer;
 	
@@ -134,12 +136,14 @@ public class TASmod implements ModInitializer, EventServerInit, EventServerStop{
 		return serverInstance;
 	}
 
+	private final Marker TEST_MARKER = MarkerManager.getMarker("INIT");
+	
 	@Override
 	public void onInitialize() {
 		logger.info("Initializing TASmod");
 		EventListener.register(this);
 		
-		logger.info("Testing connection with KillTheRNG");
+		logger.info(TEST_MARKER, "Testing connection with KillTheRNG");
 		ktrngHandler=new KillTheRNGHandler(FabricLoaderImpl.INSTANCE.isModLoaded("killtherng"));
 		EventListener.register(ktrngHandler);
 		
@@ -194,6 +198,4 @@ public class TASmod implements ModInitializer, EventServerInit, EventServerStop{
 		PacketSerializer.registerPacket(PlayUntilPacket.class);
 		
 	}
-
-
 }

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -55,6 +55,7 @@ import com.minecrafttas.tasmod.tickratechanger.CommandTickrate;
 import com.minecrafttas.tasmod.tickratechanger.PauseTickratePacket;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerServer;
 import com.minecrafttas.tasmod.ticksync.TickSyncPacket;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 import com.minecrafttas.tasmod.util.TickScheduler;
 
 import net.fabricmc.api.ModInitializer;
@@ -136,14 +137,12 @@ public class TASmod implements ModInitializer, EventServerInit, EventServerStop{
 		return serverInstance;
 	}
 
-	private final Marker TEST_MARKER = MarkerManager.getMarker("INIT");
-	
 	@Override
 	public void onInitialize() {
 		logger.info("Initializing TASmod");
 		EventListener.register(this);
 		
-		logger.info(TEST_MARKER, "Testing connection with KillTheRNG");
+		logger.info("Testing connection with KillTheRNG");
 		ktrngHandler=new KillTheRNGHandler(FabricLoaderImpl.INSTANCE.isModLoaded("killtherng"));
 		EventListener.register(ktrngHandler);
 		

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -173,7 +173,7 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 				String ip = fullsplit[0];
 				TASmodClient.packetClient = new TASmodNetworkClient(TASmod.logger, ip, 3111);
 			} else {
-				System.err.println("Something went wrong while connecting. The ip seems to be wrong");
+				TASmod.logger.error("Something went wrong while connecting. The ip seems to be wrong");
 			}
 		}
 		

--- a/src/main/java/com/minecrafttas/tasmod/commands/folder/OpenStuff.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/folder/OpenStuff.java
@@ -16,7 +16,7 @@ public class OpenStuff {
 				file.mkdir();
 			Desktop.getDesktop().open(file);
 		} catch (IOException e) {
-			TASmod.logger.fatal("Something went wrong while opening ", file.getPath());
+			TASmod.logger.error("Something went wrong while opening ", file.getPath());
 			e.printStackTrace();
 		}
 	}
@@ -28,7 +28,7 @@ public class OpenStuff {
 				file.mkdir();
 			Desktop.getDesktop().open(file);
 		} catch (IOException e) {
-			TASmod.logger.fatal("Something went wrong while opening ", file.getPath());
+			TASmod.logger.error("Something went wrong while opening ", file.getPath());
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/com/minecrafttas/tasmod/commands/fullplay/CommandFullPlay.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/fullplay/CommandFullPlay.java
@@ -2,7 +2,7 @@ package com.minecrafttas.tasmod.commands.fullplay;
 
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.playback.PlaybackController.TASstate;
-import com.minecrafttas.tasmod.savestates.server.SavestateState;
+import com.minecrafttas.tasmod.savestates.server.SavestateHandler.SavestateState;
 import com.minecrafttas.tasmod.savestates.server.exceptions.LoadstateException;
 
 import net.minecraft.command.CommandBase;

--- a/src/main/java/com/minecrafttas/tasmod/commands/fullrecord/CommandFullRecord.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/fullrecord/CommandFullRecord.java
@@ -2,7 +2,7 @@ package com.minecrafttas.tasmod.commands.fullrecord;
 
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.playback.PlaybackController.TASstate;
-import com.minecrafttas.tasmod.savestates.server.SavestateState;
+import com.minecrafttas.tasmod.savestates.server.SavestateHandler.SavestateState;
 import com.minecrafttas.tasmod.savestates.server.exceptions.SavestateException;
 
 import net.minecraft.command.CommandBase;

--- a/src/main/java/com/minecrafttas/tasmod/events/client/EventDrawHotbar.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/client/EventDrawHotbar.java
@@ -8,6 +8,7 @@ public interface EventDrawHotbar extends EventBase{
 	public void onDrawHotbar();
 	
 	public static void fireOnDrawHotbar() {
+		// No logging, because it is literally rendered every frame... This would spam the console even more
 		for (EventBase eventListener : EventListener.getEventListeners()) {
 			if(eventListener instanceof EventDrawHotbar) {
 				EventDrawHotbar event = (EventDrawHotbar) eventListener;

--- a/src/main/java/com/minecrafttas/tasmod/events/server/EventCompleteLoadstate.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/server/EventCompleteLoadstate.java
@@ -1,0 +1,24 @@
+package com.minecrafttas.tasmod.events.server;
+
+import com.minecrafttas.common.events.EventBase;
+import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.events.TASmodEventListener;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
+
+public interface EventCompleteLoadstate extends EventBase{
+	
+	/**
+	 * Fired one tick after a loadstate was carried out
+	 */
+	public void onLoadstateComplete();
+	
+	public static void fireLoadstateComplete() {
+		TASmod.logger.trace(LoggerMarkers.Event, "LoadstateCompleteEvent");
+		for (EventBase eventListener : TASmodEventListener.getEventListeners()) {
+			if(eventListener instanceof EventCompleteLoadstate) {
+				EventCompleteLoadstate event = (EventCompleteLoadstate) eventListener;
+				event.onLoadstateComplete();
+			}
+		}
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/events/server/EventLoadstate.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/server/EventLoadstate.java
@@ -16,9 +16,9 @@ public interface EventLoadstate extends EventBase {
 	
 	/**
 	 * Fired when loading a savestate, before the savestate folder is copied
-	 * @param index
-	 * @param target
-	 * @param current
+	 * @param index The savestate index for this loadstate
+	 * @param target Target folder, where the savestate is copied to
+	 * @param current The current folder that will be copied from
 	 */
 	public void onLoadstateEvent(int index, File target, File current);
 	

--- a/src/main/java/com/minecrafttas/tasmod/events/server/EventLoadstate.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/server/EventLoadstate.java
@@ -3,13 +3,27 @@ package com.minecrafttas.tasmod.events.server;
 import java.io.File;
 
 import com.minecrafttas.common.events.EventBase;
+import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.events.TASmodEventListener;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 
+/**
+ * Fired when loading a savestate, before the savestate folder is copied
+ * @author Scribble
+ *
+ */
 public interface EventLoadstate extends EventBase {
 	
+	/**
+	 * Fired when loading a savestate, before the savestate folder is copied
+	 * @param index
+	 * @param target
+	 * @param current
+	 */
 	public void onLoadstateEvent(int index, File target, File current);
 	
-	public static void fireSavestateEvent(int index, File target, File current) {
+	public static void fireLoadstateEvent(int index, File target, File current) {
+		TASmod.logger.trace(LoggerMarkers.Event, "LoadstateEvent {} {} {}", index, target, current);
 		for (EventBase eventListener : TASmodEventListener.getEventListeners()) {
 			if(eventListener instanceof EventLoadstate) {
 				EventLoadstate event = (EventLoadstate) eventListener;

--- a/src/main/java/com/minecrafttas/tasmod/events/server/EventSavestate.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/server/EventSavestate.java
@@ -16,9 +16,9 @@ public interface EventSavestate extends EventBase {
 	
 	/**
 	 * Fired when saving a savestate, before the savestate folder is copied
-	 * @param index
-	 * @param target
-	 * @param current
+	 * @param index The savestate index for this savestate
+	 * @param target Target folder, where the savestate is copied to
+	 * @param current The current folder that will be copied from
 	 */
 	public void onSavestateEvent(int index, File target, File current);
 	

--- a/src/main/java/com/minecrafttas/tasmod/events/server/EventSavestate.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/server/EventSavestate.java
@@ -3,13 +3,27 @@ package com.minecrafttas.tasmod.events.server;
 import java.io.File;
 
 import com.minecrafttas.common.events.EventBase;
+import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.events.TASmodEventListener;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 
+/**
+ * Fired when saving a savestate, before the savestate folder is copied
+ * @author Scribble
+ *
+ */
 public interface EventSavestate extends EventBase {
 	
+	/**
+	 * Fired when saving a savestate, before the savestate folder is copied
+	 * @param index
+	 * @param target
+	 * @param current
+	 */
 	public void onSavestateEvent(int index, File target, File current);
 	
 	public static void fireSavestateEvent(int index, File target, File current) {
+		TASmod.logger.trace(LoggerMarkers.Event, "SavestateEvent {} {} {}", index, target, current);
 		for (EventBase eventListener : TASmodEventListener.getEventListeners()) {
 			if(eventListener instanceof EventSavestate) {
 				EventSavestate event = (EventSavestate) eventListener;

--- a/src/main/java/com/minecrafttas/tasmod/handlers/LoadingScreenHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/handlers/LoadingScreenHandler.java
@@ -6,6 +6,7 @@ import com.minecrafttas.common.events.client.EventLaunchIntegratedServer;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.TASmodClient;
 import com.minecrafttas.tasmod.playback.PlaybackController;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 
 import net.minecraft.client.Minecraft;
 
@@ -23,7 +24,7 @@ public class LoadingScreenHandler implements EventLaunchIntegratedServer, EventC
 
 	@Override
 	public void onLaunchIntegratedServer() {
-		TASmod.logger.info("Starting the integrated server");
+		TASmod.logger.debug(LoggerMarkers.Event, "Starting the integrated server");
 		PlaybackController container = TASmodClient.virtual.getContainer();
 		if(!container.isNothingPlaying() && !container.isPaused()) {
 			container.pause(true);
@@ -38,7 +39,7 @@ public class LoadingScreenHandler implements EventLaunchIntegratedServer, EventC
 	public void onRunClientGameLoop(Minecraft mc) {
 		if (loadingScreenDelay > -1) {
 			if (loadingScreenDelay == 0) {
-				TASmod.logger.info("Finished loading screen on the client");
+				TASmod.logger.debug(LoggerMarkers.Event, "Finished loading screen on the client");
 				TASmodClient.tickratechanger.joinServer();
 				if (!waszero) {
 					if(TASmod.getServerInstance()!=null) {	//Check if a server is running and if it's an integrated server
@@ -57,6 +58,7 @@ public class LoadingScreenHandler implements EventLaunchIntegratedServer, EventC
 	@Override
 	public void onDoneLoadingWorld() {
 		if(TASmod.getServerInstance()!=null) { //Check if a server is running and if it's an integrated server
+			TASmod.logger.debug(LoggerMarkers.Event, "Finished loading the world on the client");
 			loadingScreenDelay = 1;
 		}
 	}

--- a/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraftServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraftServer.java
@@ -11,8 +11,8 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import com.minecrafttas.tasmod.TASmod;
-import com.minecrafttas.tasmod.savestates.server.SavestateHandler;
-import com.minecrafttas.tasmod.savestates.server.SavestateState;
+import com.minecrafttas.tasmod.events.server.EventCompleteLoadstate;
+import com.minecrafttas.tasmod.savestates.server.SavestateHandler.SavestateState;
 import com.minecrafttas.tasmod.ticksync.TickSyncServer;
 
 import net.fabricmc.api.EnvType;
@@ -73,7 +73,7 @@ public abstract class MixinMinecraftServer {
 			
 			if (TASmod.savestateHandler.state == SavestateState.WASLOADING) {
 				TASmod.savestateHandler.state = SavestateState.NONE;
-				SavestateHandler.playerLoadSavestateEventServer();
+				EventCompleteLoadstate.fireLoadstateComplete();
 			}
 
 			this.tick();

--- a/src/main/java/com/minecrafttas/tasmod/mixin/savestates/MixinNetHandlerPlayServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/savestates/MixinNetHandlerPlayServer.java
@@ -5,7 +5,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import com.minecrafttas.tasmod.TASmod;
-import com.minecrafttas.tasmod.savestates.server.SavestateState;
+import com.minecrafttas.tasmod.savestates.server.SavestateHandler.SavestateState;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.NetHandlerPlayServer;

--- a/src/main/java/com/minecrafttas/tasmod/networking/PacketSerializer.java
+++ b/src/main/java/com/minecrafttas/tasmod/networking/PacketSerializer.java
@@ -67,15 +67,16 @@ public class PacketSerializer {
 	}
 	
 	public static void registerPacket(Class<? extends Packet> packet) {
+		TASmod.logger.trace("Registering packet {}", packet.getClass().getSimpleName());
 		if(REGISTRY.contains(packet)) {
-			TASmod.logger.warn("Trying to register packet which already exists: "+packet.getClass().getSimpleName());
+			TASmod.logger.warn("Trying to register packet which already exists: {}", packet.getClass().getSimpleName());
 		}
 		REGISTRY.add(packet);
 	}
 
 	public static void unregisterPacket(Class<? extends Packet> packet) {
 		if(REGISTRY.contains(packet)) {
-			TASmod.logger.warn("Trying to unregister packet which doesn't exist in the registry: "+packet.getClass().getSimpleName());
+			TASmod.logger.warn("Trying to unregister packet which doesn't exist in the registry: {}", packet.getClass().getSimpleName());
 		}
 		REGISTRY.remove(packet);
 	}

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackController.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackController.java
@@ -17,6 +17,7 @@ import com.minecrafttas.tasmod.networking.Packet;
 import com.minecrafttas.tasmod.networking.PacketSide;
 import com.minecrafttas.tasmod.playback.controlbytes.ControlByteHandler;
 import com.minecrafttas.tasmod.playback.server.TASstateClient;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 import com.minecrafttas.tasmod.virtual.VirtualInput;
 import com.minecrafttas.tasmod.virtual.VirtualKeyboard;
 import com.minecrafttas.tasmod.virtual.VirtualMouse;
@@ -152,6 +153,7 @@ public class PlaybackController implements EventOpenGui{
 		} else if (state == TASstate.NONE) { // If the container is currently doing nothing
 			switch (stateIn) {
 			case PLAYBACK:
+				TASmod.logger.debug(LoggerMarkers.Playback, "Starting playback");
 				if (Minecraft.getMinecraft().player != null && !startLocation.isEmpty()) {
 					try {
 						tpPlayer(startLocation);
@@ -168,13 +170,13 @@ public class PlaybackController implements EventOpenGui{
 				TASmod.ktrngHandler.setInitialSeed(startSeed);
 				return verbose ? TextFormatting.GREEN + "Starting playback" : "";
 			case RECORDING:
+				TASmod.logger.debug(LoggerMarkers.Playback, "Starting recording");
 				if (Minecraft.getMinecraft().player != null && startLocation.isEmpty()) {
 					startLocation = getStartLocation(Minecraft.getMinecraft().player);
 				}
 				if(this.inputs.isEmpty()) {
 					inputs.add(new TickInputContainer(index));
 					desyncMonitor.recordNull(index);
-//					desyncMonitor.recordNull(index+1);
 				}
 				state = TASstate.RECORDING;
 				return verbose ? TextFormatting.GREEN + "Starting a recording" : "";
@@ -190,10 +192,12 @@ public class PlaybackController implements EventOpenGui{
 			case RECORDING:
 				return TextFormatting.RED + "Please report this message to the mod author, because you should never be able to see this (Error: Recording)";
 			case PAUSED:
+				TASmod.logger.debug(LoggerMarkers.Playback, "Pausing a recording");
 				state = TASstate.PAUSED;
 				tempPause = TASstate.RECORDING;
 				return verbose ? TextFormatting.GREEN + "Pausing a recording" : "";
 			case NONE:
+				TASmod.logger.debug(LoggerMarkers.Playback, "Stopping a recording");
 				TASmodClient.virtual.unpressEverything();
 				state = TASstate.NONE;
 				return verbose ? TextFormatting.GREEN + "Stopping the recording" : "";
@@ -205,11 +209,13 @@ public class PlaybackController implements EventOpenGui{
 			case RECORDING:
 				return verbose ? TextFormatting.RED + "A playback is currently running. Please stop the playback first before starting a recording" : "";
 			case PAUSED:
+				TASmod.logger.debug(LoggerMarkers.Playback, "Pausing a playback");
 				state = TASstate.PAUSED;
 				tempPause = TASstate.PLAYBACK;
 				TASmodClient.virtual.unpressEverything();
 				return verbose ? TextFormatting.GREEN + "Pausing a playback" : "";
 			case NONE:
+				TASmod.logger.debug(LoggerMarkers.Playback, "Stopping a playback");
 				Minecraft.getMinecraft().gameSettings.chatLinks = true;
 				TASmodClient.virtual.unpressEverything();
 				state = TASstate.NONE;
@@ -218,16 +224,19 @@ public class PlaybackController implements EventOpenGui{
 		} else if (state == TASstate.PAUSED) {
 			switch (stateIn) {
 			case PLAYBACK:
+				TASmod.logger.debug(LoggerMarkers.Playback, "Resuming a playback");
 				state=TASstate.PLAYBACK;
 				tempPause=TASstate.NONE;
 				return verbose ? TextFormatting.GREEN + "Resuming a playback" : "";
 			case RECORDING:
+				TASmod.logger.debug(LoggerMarkers.Playback, "Resuming a recording");
 				state=TASstate.RECORDING;
 				tempPause=TASstate.NONE;
 				return verbose ? TextFormatting.GREEN + "Resuming a recording" : "";
 			case PAUSED:
 				return TextFormatting.RED + "Please report this message to the mod author, because you should never be able to see this (Error: Paused)";
 			case NONE:
+				TASmod.logger.debug(LoggerMarkers.Playback, "Aborting pausing");
 				state=TASstate.NONE;
 				TASstate statey=tempPause;
 				tempPause=TASstate.NONE;
@@ -255,6 +264,7 @@ public class PlaybackController implements EventOpenGui{
 	 * @param pause True, if it should be paused
 	 */
 	public void pause(boolean pause) {
+		TASmod.logger.trace(LoggerMarkers.Playback, "Pausing {}", pause);
 		if(pause) {
 			if(state!=TASstate.NONE) {
 				setTASState(TASstate.PAUSED, false);
@@ -393,11 +403,13 @@ public class PlaybackController implements EventOpenGui{
 	private void playbackNextTick() {
 		
 		if (!Display.isActive()) { // Stops the playback when you tab out of minecraft, for once as a failsafe, secondly as potential exploit protection
+			TASmod.logger.info(LoggerMarkers.Playback, "Stopping a {} since the user tabbed out of the game", state);
 			setTASState(TASstate.NONE);
 		}
 		
 		index++;	// Increase the index and load the next inputs
 		
+		/*Playuntil logic*/
 		if(playUntil!=null && playUntil == index) {
 			TASmodClient.tickratechanger.pauseGame(true);
 			playUntil = null;
@@ -485,6 +497,7 @@ public class PlaybackController implements EventOpenGui{
 	}
 
 	public void clear() {
+		TASmod.logger.debug(LoggerMarkers.Playback, "Clearing playback controller");
 		inputs = new BigArrayList<TickInputContainer>(directory + File.separator + "temp");
 		controlBytes.clear();
 		comments.clear();
@@ -585,6 +598,7 @@ public class PlaybackController implements EventOpenGui{
 	 * @param startLocation The start location of the TAS
 	 */
 	public void setStartLocation(String startLocation) {
+		TASmod.logger.debug(LoggerMarkers.Playback, "Setting start location");
 		this.startLocation = startLocation;
 	}
 
@@ -595,6 +609,7 @@ public class PlaybackController implements EventOpenGui{
 	 * @return The start location from the player
 	 */
 	private String getStartLocation(EntityPlayerSP player) {
+		TASmod.logger.debug(LoggerMarkers.Playback, "Retrieving player start location");
 		String pos = player.posX + "," + player.posY + "," + player.posZ;
 		String pitch = Float.toString(player.rotationPitch);
 		String yaw = Float.toString(player.rotationYaw);
@@ -609,6 +624,7 @@ public class PlaybackController implements EventOpenGui{
 	 * @throws NumberFormatException If the location can't be parsed
 	 */
 	private void tpPlayer(String startLocation) throws NumberFormatException {
+		TASmod.logger.debug(LoggerMarkers.Playback, "Teleporting the player to the start location");
 		String[] section = startLocation.split(",");
 		double x = Double.parseDouble(section[0]);
 		double y = Double.parseDouble(section[1]);
@@ -687,6 +703,7 @@ public class PlaybackController implements EventOpenGui{
 	 * Clears {@link #keyboard} and {@link #mouse}
 	 */
 	public void unpressContainer() {
+		TASmod.logger.trace(LoggerMarkers.Playback, "Unpressing container");
 		keyboard.clear();
 		mouse.clear();
 	}
@@ -694,6 +711,7 @@ public class PlaybackController implements EventOpenGui{
 	// ==============================================================
 
 	public void printCredits() {
+		TASmod.logger.trace(LoggerMarkers.Playback, "Printing credits");
 		if (state == TASstate.PLAYBACK&&!creditsPrinted) {
 			creditsPrinted=true;
 			printMessage(title, ChatFormatting.GOLD);
@@ -839,6 +857,7 @@ public class PlaybackController implements EventOpenGui{
 	private TASstate stateWhenOpened;
 	
 	public void setStateWhenOpened(TASstate state) {
+		TASmod.logger.trace(LoggerMarkers.Playback, "Set state when opened to {}", state);
 		stateWhenOpened = state;
 	}
 	

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackSerialiser.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackSerialiser.java
@@ -16,6 +16,7 @@ import com.minecrafttas.tasmod.monitoring.DesyncMonitoring;
 import com.minecrafttas.tasmod.playback.PlaybackController.TickInputContainer;
 import com.minecrafttas.tasmod.playback.controlbytes.ControlByteHandler;
 import com.minecrafttas.tasmod.util.FileThread;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 import com.minecrafttas.tasmod.virtual.VirtualKey;
 import com.minecrafttas.tasmod.virtual.VirtualKeyboard;
 import com.minecrafttas.tasmod.virtual.VirtualMouse;
@@ -97,6 +98,7 @@ public class PlaybackSerialiser {
 	 * @throws IOException When the input container is empty
 	 */
 	public void saveToFileV1Until(File file, PlaybackController container, int index) throws IOException{
+		TASmod.logger.debug(LoggerMarkers.Playback, "Saving playback controller to file {}", file);
 		if (container.size() == 0) {
 			throw new IOException("There are no inputs to save to a file");
 		}
@@ -162,6 +164,7 @@ public class PlaybackSerialiser {
 	}
 
 	public int getFileVersion(File file) throws IOException {
+		TASmod.logger.trace(LoggerMarkers.Playback, "Retrieving file version from {}", file);
 		List<String> lines = FileUtils.readLines(file, Charset.defaultCharset());
 		for (String line : lines) {
 			if (line.contains("Version")) {
@@ -179,7 +182,7 @@ public class PlaybackSerialiser {
 	}
 
 	public PlaybackController fromEntireFileV1(File file) throws IOException {
-
+		TASmod.logger.debug(LoggerMarkers.Playback, "Loading playback controller to file {}", file);
 		List<String> lines = FileUtils.readLines(file, StandardCharsets.UTF_8);
 		
 		File monitorFile=new File(file, "../"+file.getName().replace(".mctas", "")+".mon");

--- a/src/main/java/com/minecrafttas/tasmod/savestates/client/InputSavestatesHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/client/InputSavestatesHandler.java
@@ -8,6 +8,7 @@ import com.minecrafttas.tasmod.TASmodClient;
 import com.minecrafttas.tasmod.playback.PlaybackController;
 import com.minecrafttas.tasmod.playback.PlaybackController.TASstate;
 import com.minecrafttas.tasmod.savestates.server.exceptions.SavestateException;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 import com.mojang.realmsclient.gui.ChatFormatting;
 
 import net.fabricmc.api.EnvType;
@@ -36,9 +37,9 @@ public class InputSavestatesHandler {
 	 * @throws IOException
 	 */
 	public static void savestate(String nameOfSavestate) throws SavestateException, IOException {
-
+		TASmod.logger.debug(LoggerMarkers.Savestate, "Saving client savestate {}", nameOfSavestate);
 		if (nameOfSavestate.isEmpty()) {
-			TASmod.logger.error("No recording savestate loaded since the name of savestate is empty");
+			TASmod.logger.error(LoggerMarkers.Savestate, "No recording savestate loaded since the name of savestate is empty");
 			return;
 		}
 
@@ -63,9 +64,9 @@ public class InputSavestatesHandler {
 	 * @throws IOException
 	 */
 	public static void loadstate(String nameOfSavestate) throws IOException {
-
+		TASmod.logger.debug(LoggerMarkers.Savestate, "Loading client savestate {}", nameOfSavestate);
 		if (nameOfSavestate.isEmpty()) {
-			TASmod.logger.error("No recording savestate loaded since the name of savestate is empty");
+			TASmod.logger.error(LoggerMarkers.Savestate, "No recording savestate loaded since the name of savestate is empty");
 			return;
 		}
 
@@ -81,7 +82,7 @@ public class InputSavestatesHandler {
 				TASmodClient.virtual.getContainer().setTASState(TASstate.NONE, false);
 				Minecraft.getMinecraft().player.sendMessage(new TextComponentString(ChatFormatting.YELLOW
 						+ "Inputs could not be loaded for this savestate, since the file doesn't exist. Stopping!"));
-				TASmod.logger.warn("Inputs could not be loaded for this savestate, since the file doesn't exist.");
+				TASmod.logger.warn(LoggerMarkers.Savestate, "Inputs could not be loaded for this savestate, since the file doesn't exist.");
 			}
 		}
 	}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/client/gui/GuiSavestateLoadingScreen.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/client/gui/GuiSavestateLoadingScreen.java
@@ -7,9 +7,6 @@ import net.minecraft.client.resources.I18n;
 
 public class GuiSavestateLoadingScreen extends GuiScreen {
 
-//	private static boolean copying;
-//	private static boolean deleting;
-
 	@Override
 	public void drawScreen(int mouseX, int mouseY, float partialTicks) {
 		this.drawDefaultBackground();

--- a/src/main/java/com/minecrafttas/tasmod/savestates/server/LoadstatePacket.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/server/LoadstatePacket.java
@@ -3,6 +3,7 @@ package com.minecrafttas.tasmod.savestates.server;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.networking.Packet;
 import com.minecrafttas.tasmod.networking.PacketSide;
+import com.minecrafttas.tasmod.savestates.server.SavestateHandler.SavestateState;
 import com.minecrafttas.tasmod.savestates.server.chunkloading.SavestatesChunkControl;
 import com.minecrafttas.tasmod.savestates.server.exceptions.LoadstateException;
 

--- a/src/main/java/com/minecrafttas/tasmod/savestates/server/SavestateCommand.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/server/SavestateCommand.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.savestates.server.SavestateHandler.SavestateState;
 import com.minecrafttas.tasmod.savestates.server.exceptions.LoadstateException;
 import com.minecrafttas.tasmod.savestates.server.exceptions.SavestateDeleteException;
 import com.minecrafttas.tasmod.savestates.server.exceptions.SavestateException;

--- a/src/main/java/com/minecrafttas/tasmod/savestates/server/SavestatePacket.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/server/SavestatePacket.java
@@ -4,6 +4,7 @@ import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.networking.Packet;
 import com.minecrafttas.tasmod.networking.PacketSide;
 import com.minecrafttas.tasmod.savestates.client.gui.GuiSavestateSavingScreen;
+import com.minecrafttas.tasmod.savestates.server.SavestateHandler.SavestateState;
 import com.minecrafttas.tasmod.savestates.server.exceptions.SavestateException;
 
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/minecrafttas/tasmod/savestates/server/SavestateState.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/server/SavestateState.java
@@ -1,8 +1,0 @@
-package com.minecrafttas.tasmod.savestates.server;
-
-public enum SavestateState {
-	SAVING,
-	LOADING,
-	WASLOADING,
-	NONE
-}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/server/chunkloading/SavestatesChunkControl.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/server/chunkloading/SavestatesChunkControl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.mixin.savestates.MixinChunkProviderClient;
 import com.minecrafttas.tasmod.mixin.savestates.MixinChunkProviderServer;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 import com.minecrafttas.tasmod.util.Ducks.ChunkProviderDuck;
 
 import net.fabricmc.api.EnvType;
@@ -22,7 +23,7 @@ import net.minecraft.world.gen.ChunkProviderServer;
 import net.minecraft.world.storage.SaveHandler;
 /**
  * Various methods to unload/reload chunks and make loadless savestates possible
- * @author ScribbleLP
+ * @author Scribble
  *
  */
 public class SavestatesChunkControl {
@@ -34,6 +35,7 @@ public class SavestatesChunkControl {
 	 */
 	@Environment(EnvType.CLIENT)
 	public static void unloadAllClientChunks() {
+		TASmod.logger.trace(LoggerMarkers.Savestate, "Unloading All Client Chunks");
 		Minecraft mc = Minecraft.getMinecraft();
 		
 		ChunkProviderClient chunkProvider=mc.world.getChunkProvider();
@@ -48,6 +50,7 @@ public class SavestatesChunkControl {
 	 * @see MixinChunkProviderServer#unloadAllChunks()
 	 */
 	public static void unloadAllServerChunks(MinecraftServer server) {
+		TASmod.logger.trace(LoggerMarkers.Savestate, "Unloading all server chunks");
 		//Vanilla
 		WorldServer[] worlds=server.worlds;
 		
@@ -71,6 +74,7 @@ public class SavestatesChunkControl {
 		WorldServer[] worlds=server.worlds;
 		for (WorldServer world : worlds) {
 			for (EntityPlayerMP player : players) {
+				TASmod.logger.trace(LoggerMarkers.Savestate, "Disconnect player {} from the chunk map", player.getName());
 				world.getPlayerChunkMap().removePlayer(player);
 			}
 		}
@@ -87,6 +91,7 @@ public class SavestatesChunkControl {
 		//Vanilla
 		WorldServer[] worlds=server.worlds;
 		for (EntityPlayerMP player : players) {
+			TASmod.logger.trace(LoggerMarkers.Savestate, "Add player {} to the chunk map", player.getName());
 			switch (player.dimension) {
 			case -1:
 				worlds[1].getPlayerChunkMap().addPlayer(player);
@@ -109,6 +114,7 @@ public class SavestatesChunkControl {
 	 * Side: Server
 	 */
 	public static void flushSaveHandler(MinecraftServer server) {
+		TASmod.logger.trace(LoggerMarkers.Savestate, "Flush the save handler");
 		//Vanilla
 		WorldServer[] worlds=server.worlds;
 		for(WorldServer world : worlds) {
@@ -131,6 +137,7 @@ public class SavestatesChunkControl {
 	 * Side: Server
 	 */
 	public static void updateSessionLock(MinecraftServer server) {
+		TASmod.logger.trace(LoggerMarkers.Savestate, "Update the session lock");
 		WorldServer[] worlds=server.worlds;
 		for(WorldServer world : worlds) {
 			((SaveHandler) world.getSaveHandler()).setSessionLock();
@@ -150,6 +157,7 @@ public class SavestatesChunkControl {
 	 */
 	@Environment(EnvType.CLIENT)
 	public static void keepPlayerInLoadedEntityList(net.minecraft.entity.player.EntityPlayer player) {
+		TASmod.logger.trace(LoggerMarkers.Savestate, "Keep player {} in loaded entity list", player.getName());
 		Minecraft.getMinecraft().world.unloadedEntityList.remove(player);
 	}
 	
@@ -169,6 +177,7 @@ public class SavestatesChunkControl {
 	 */
 	@Environment(EnvType.CLIENT)
 	public static void addPlayerToClientChunk(EntityPlayer player) {
+		TASmod.logger.trace(LoggerMarkers.Savestate, "Add player {} to loaded entity list", player.getName());
 		int i = MathHelper.floor(player.posX / 16.0D);
 		int j = MathHelper.floor(player.posZ / 16.0D);
 		Chunk chunk = Minecraft.getMinecraft().world.getChunkFromChunkCoords(i, j);
@@ -187,6 +196,7 @@ public class SavestatesChunkControl {
 	 * Side: Server
 	 */
 	public static void addPlayerToServerChunk(EntityPlayerMP player) {
+		TASmod.logger.trace(LoggerMarkers.Savestate, "Add player {} to server chunk", player.getName());
 		int i = MathHelper.floor(player.posX / 16.0D);
 		int j = MathHelper.floor(player.posZ / 16.0D);
 		WorldServer world = player.getServerWorld();
@@ -203,6 +213,7 @@ public class SavestatesChunkControl {
 	 * Updates ticklist entries to the current world time, allowing them to not be stuck in a pressed state #136
 	 */
 	public static void updateWorldServerTickListEntries() {
+		TASmod.logger.trace(LoggerMarkers.Savestate, "Update server tick list entries");
 		MinecraftServer server=TASmod.getServerInstance();
 		for (WorldServer world : server.worlds) {
             for (NextTickListEntry nextticklistentry : world.pendingTickListEntriesHashSet) {

--- a/src/main/java/com/minecrafttas/tasmod/savestates/server/motion/ClientMotionServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/server/motion/ClientMotionServer.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import com.google.common.collect.Maps;
 import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 
@@ -16,6 +17,7 @@ public class ClientMotionServer {
 	}
 
 	public static void requestMotionFromClient() {
+		TASmod.logger.trace(LoggerMarkers.Savestate, "Request motion from client");
 		motion.clear();
 		TASmod.packetServer.sendToAll(new RequestMotionPacket());
 
@@ -28,11 +30,11 @@ public class ClientMotionServer {
 				e.printStackTrace();
 			}
 			if(i % 30 == 1) {
-				TASmod.logger.info("Resending motion packet");
+				TASmod.logger.debug(LoggerMarkers.Savestate, "Resending motion packet");
 				TASmod.packetServer.sendToAll(new RequestMotionPacket());
 			}
 			if (i == 1000) {
-				TASmod.logger.warn("Client motion timed out!");
+				TASmod.logger.warn(LoggerMarkers.Savestate, "Client motion timed out!");
 				break;
 			}
 

--- a/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerClient.java
@@ -4,6 +4,7 @@ import com.minecrafttas.common.events.client.EventClientGameLoop;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.TASmodClient;
 import com.minecrafttas.tasmod.ticksync.TickSyncClient;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 
 import net.minecraft.client.Minecraft;
 
@@ -175,7 +176,7 @@ public class TickrateChangerClient implements EventClientGameLoop{
 	}
 	
 	private static void log(String msg) {
-		TASmod.logger.info(msg);
+		TASmod.logger.debug(LoggerMarkers.Tickrate, msg);
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerServer.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import com.minecrafttas.common.events.server.EventServerStop;
 import com.minecrafttas.common.events.server.player.EventPlayerJoinedServerSide;
 import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
@@ -194,7 +195,7 @@ public class TickrateChangerServer implements EventServerStop, EventPlayerJoined
 	 * @param msg 
 	 */
 	private void log(String msg) {
-		logger.info(msg);
+		logger.debug(LoggerMarkers.Tickrate, msg);
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/util/LoggerMarkers.java
+++ b/src/main/java/com/minecrafttas/tasmod/util/LoggerMarkers.java
@@ -1,0 +1,38 @@
+package com.minecrafttas.tasmod.util;
+
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+
+/**
+ * <p>A list of Log4J markers which can be added to logging statements.
+ * 
+ * <p>Simply add the marker as the first argument:
+ * <pre>TASmod.logger.info({@linkplain LoggerMarkers}.{@link #Event}, "Message");</pre>
+ * 
+ * <p>You can then turn off log messages by adding a VM option to your run configuration:
+ * <pre>-Dtasmod.marker.event=DENY</pre>
+ * 
+ * <p>To add new markers, follow the pattern in this class then head to src/main/resources/log4j.xml.
+ * There you can add the marker to the 'Filters' xml-tag
+ * 
+ * <pre>
+ * 	&lt;Filters&gt;
+ * 		&lt;MarkerFilter marker="Event" onMatch="${sys:tasmod.marker.event:-ACCEPT}" onMismatch="NEUTRAL" /&gt;
+ * 	&lt;/Filters&gt;
+ * 	</pre>
+ * 
+ * @author Scribble
+ *
+ */
+public class LoggerMarkers {
+	
+	public static final Marker Event = MarkerManager.getMarker("Event");
+	
+	public static final Marker Savestate = MarkerManager.getMarker("Savestate");
+	
+	public static final Marker Networking = MarkerManager.getMarker("Networking");
+	
+	public static final Marker Tickrate = MarkerManager.getMarker("Tickrate");
+
+	public static final Marker Playback = MarkerManager.getMarker("Playback");
+}

--- a/src/main/resources/common.mixin.json
+++ b/src/main/resources/common.mixin.json
@@ -2,6 +2,7 @@
     "required": true,
     "minVersion": "0.8.5",
     "package": "com.minecrafttas.common.mixin",
+    "refmap": "tasmod.refmap.json",
     "compatibilityLevel": "JAVA_8",
     "mixins": [
         "MixinMinecraftServer",

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" packages="com.mojang.util,net.minecrell.terminalconsole.util">
+	<Appenders>
+
+		<!--	System out	-->
+		<Console name="SysOut" target="SYSTEM_OUT">
+			<PatternLayout>
+				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="false">
+					<!-- Dont show the logger name for minecraft classes-->
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(Minecraft)}{cyan} %highlight{%msg{nolookups}%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
+					<PatternMatch key="TASmod" pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1}%notEmpty{/%marker})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
+				</LoggerNamePatternSelector>
+			</PatternLayout>
+			<MarkerFilter marker="INIT" onMatch="NEUTRAL" onMismatch="NEUTRAL"/>
+		</Console>
+
+		<!--	Vanilla server gui	-->
+		<Queue name="ServerGuiConsole" ignoreExceptions="true">
+			<PatternLayout>
+				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss} %level] (%logger{1}) %msg{nolookups}%n">
+					<!-- Dont show the logger name for minecraft classes-->
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss} %level] %msg{nolookups}%n"/>
+					<PatternMatch key="TASmod" pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1}%notEmpty{/%marker})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
+				</LoggerNamePatternSelector>
+			</PatternLayout>
+		</Queue>
+
+		<!--	latest.log same as vanilla	-->
+		<RollingRandomAccessFile name="LatestFile" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
+			<PatternLayout>
+				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level] (%logger{1}) %msg{nolookups}%n">
+					<!-- Dont show the logger name for minecraft classes-->
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss}] [%t/%level] (Minecraft) %msg{nolookups}%n"/>
+					<PatternMatch key="TASmod" pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1}%notEmpty{/%marker})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
+				</LoggerNamePatternSelector>
+			</PatternLayout>
+			<Policies>
+				<TimeBasedTriggeringPolicy />
+				<OnStartupTriggeringPolicy />
+			</Policies>
+		</RollingRandomAccessFile>
+
+		<!--	Debug log file	-->
+		<RollingRandomAccessFile name="DebugFile" fileName="logs/debug.log" filePattern="logs/debug-%i.log.gz">
+			<PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] (%logger) %msg{nolookups}%n" />
+
+			<!--	Keep 5 files max	-->
+			<DefaultRolloverStrategy max="5" fileIndex="min"/>
+
+			<Policies>
+				<SizeBasedTriggeringPolicy size="200MB"/>
+				<OnStartupTriggeringPolicy />
+			</Policies>
+
+		</RollingRandomAccessFile>
+	</Appenders>
+	<Loggers>
+		<Logger level="${sys:fabric.log.level:-info}" name="net.minecraft"/>
+		<Root level="all">
+			<AppenderRef ref="DebugFile" level="${sys:fabric.log.debug.level:-debug}"/>
+			<AppenderRef ref="SysOut" level="${sys:fabric.log.level:-info}"/>
+			<AppenderRef ref="LatestFile" level="${sys:fabric.log.level:-info}"/>
+			<AppenderRef ref="ServerGuiConsole" level="${sys:fabric.log.level:-info}"/>
+		</Root>
+	</Loggers>
+</Configuration>

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -1,66 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="com.mojang.util,net.minecrell.terminalconsole.util">
+<Configuration status="WARN" packages="com.minecrafttas.">
+	<Filters>
+		<MarkerFilter marker="Event"
+			onMatch="${sys:tasmod.marker.event:-ACCEPT}" onMismatch="NEUTRAL" />
+		<MarkerFilter marker="Savestate"
+			onMatch="${sys:tasmod.marker.savestate:-ACCEPT}" onMismatch="NEUTRAL" />
+		<MarkerFilter marker="Networking"
+			onMatch="${sys:tasmod.marker.networking:-ACCEPT}" onMismatch="NEUTRAL" />
+		<MarkerFilter marker="Tickrate"
+			onMatch="${sys:tasmod.marker.tickrate:-ACCEPT}" onMismatch="NEUTRAL" />
+		<MarkerFilter marker="Playback"
+			onMatch="${sys:tasmod.marker.playback:-ACCEPT}" onMismatch="NEUTRAL" />
+	</Filters>
 	<Appenders>
-
-		<!--	System out	-->
-		<Console name="SysOut" target="SYSTEM_OUT">
-			<PatternLayout>
-				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="false">
-					<!-- Dont show the logger name for minecraft classes-->
-					<PatternMatch key="net.minecraft.,com.mojang." pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(Minecraft)}{cyan} %highlight{%msg{nolookups}%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
-					<PatternMatch key="TASmod" pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1}%notEmpty{/%marker})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
-				</LoggerNamePatternSelector>
+		<Console name="SysOut2" target="SYSTEM_OUT">
+			<PatternLayout disableAnsi="${sys:fabric.log.disableAnsi:-true}">
+					<pattern>%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1}%notEmpty{/%marker})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}</pattern>
 			</PatternLayout>
-			<MarkerFilter marker="INIT" onMatch="NEUTRAL" onMismatch="NEUTRAL"/>
 		</Console>
-
-		<!--	Vanilla server gui	-->
-		<Queue name="ServerGuiConsole" ignoreExceptions="true">
-			<PatternLayout>
-				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss} %level] (%logger{1}) %msg{nolookups}%n">
-					<!-- Dont show the logger name for minecraft classes-->
-					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss} %level] %msg{nolookups}%n"/>
-					<PatternMatch key="TASmod" pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1}%notEmpty{/%marker})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
-				</LoggerNamePatternSelector>
-			</PatternLayout>
-		</Queue>
-
-		<!--	latest.log same as vanilla	-->
-		<RollingRandomAccessFile name="LatestFile" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
-			<PatternLayout>
-				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level] (%logger{1}) %msg{nolookups}%n">
-					<!-- Dont show the logger name for minecraft classes-->
-					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss}] [%t/%level] (Minecraft) %msg{nolookups}%n"/>
-					<PatternMatch key="TASmod" pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1}%notEmpty{/%marker})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}"/>
-				</LoggerNamePatternSelector>
-			</PatternLayout>
-			<Policies>
-				<TimeBasedTriggeringPolicy />
-				<OnStartupTriggeringPolicy />
-			</Policies>
-		</RollingRandomAccessFile>
-
-		<!--	Debug log file	-->
-		<RollingRandomAccessFile name="DebugFile" fileName="logs/debug.log" filePattern="logs/debug-%i.log.gz">
-			<PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] (%logger) %msg{nolookups}%n" />
-
-			<!--	Keep 5 files max	-->
-			<DefaultRolloverStrategy max="5" fileIndex="min"/>
-
-			<Policies>
-				<SizeBasedTriggeringPolicy size="200MB"/>
-				<OnStartupTriggeringPolicy />
-			</Policies>
-
-		</RollingRandomAccessFile>
 	</Appenders>
 	<Loggers>
-		<Logger level="${sys:fabric.log.level:-info}" name="net.minecraft"/>
-		<Root level="all">
-			<AppenderRef ref="DebugFile" level="${sys:fabric.log.debug.level:-debug}"/>
-			<AppenderRef ref="SysOut" level="${sys:fabric.log.level:-info}"/>
-			<AppenderRef ref="LatestFile" level="${sys:fabric.log.level:-info}"/>
-			<AppenderRef ref="ServerGuiConsole" level="${sys:fabric.log.level:-info}"/>
-		</Root>
+		<Logger level="${sys:tasmod.log.level:-info}" name="TASmod" additivity="false">
+			<AppenderRef ref="SysOut2" level="${sys:tasmod.log.level:-info}"/>
+		</Logger>
 	</Loggers>
 </Configuration>

--- a/src/main/resources/tasmod.mixin.json
+++ b/src/main/resources/tasmod.mixin.json
@@ -2,6 +2,7 @@
     "required": true,
     "minVersion": "0.8.5",
     "package": "com.minecrafttas.tasmod.mixin",
+    "refmap": "tasmod.refmap.json",
     "compatibilityLevel": "JAVA_8",
     "mixins": [
     
@@ -20,7 +21,7 @@
         
         //Fixing forge and vanilla stuff
         "fixes.MixinDragonFightManager",
-        "fixes.MixinNetworkManager",
+        "fixes.MixinNetworkManager"
         
     ],
     "client": [
@@ -60,6 +61,6 @@
 		
 		//Shields
 		"shields.MixinRenderItem",
-		"shields.MixinTileEntityItemStackRenderer",
+		"shields.MixinTileEntityItemStackRenderer"
 	]
 }


### PR DESCRIPTION
Add a custom log4jconfig to the mod which allows markers, ansi-coloring and debug log level

## Markers
Markers allow you to filter log messages later  
To add a marker to log messages use:
```java
TASmod.logger.info(LoggerMarkers.Event, "Message");
```
This message can then later be disabled with 
```
-Dtasmod.marker.event=DENY
```
A new marker has to be added in the log4j.xml like this under `<Filters>`:
```xml
	<MarkerFilter marker="Event" onMatch="${sys:tasmod.marker.event:-ACCEPT}" onMismatch="NEUTRAL" />
```
## TASmod log level
The TASmod logger now has a seperate log level from the regular fabric one.  
It can be accessed with
```
-Dtasmod.log.level=INFO
```

## Misc

- Added more debug log messages and trace log messages
- Minor improvements to SavestateHandler
- Removed printing a stacktrace when no config file was found

## Todo
Markers to be added:

- [x] Events
- [x] Savestates
- [x] Networking //Add during packet rework!
- [x] Playback
- [x] Tickratechanger

Closes #154