### PR TITLE
[Common] Add support for custom language files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2.4.0
       with:
-        gradle-version: 8.1.1
+        gradle-version: 8.4
     - name: Build TASmod with Gradle
       run: gradle build
     - name: Upload Test Report

--- a/.github/workflows/buildandupload.yml
+++ b/.github/workflows/buildandupload.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2.4.0
       with:
-        gradle-version: 8.1.1
+        gradle-version: 8.4
     - name: Build TASmod with Gradle
       run: gradle build
     - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ out
 # gradle
 build
 .gradle
+gradle
+gradlew
+gradlew.bat
 
 # other
 eclipse

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,7 @@ configurations {
 // dependencies
 dependencies {
     // tasmod dependencies
-    embed group: 'com.dselent', name: 'bigarraylist', version: '1.0'
-    
+    embed group: 'com.dselent', name: 'bigarraylist', version: '1.1'
     compileOnly group: 'com.minecrafttas', name: 'killtherng', version: '2.0'
     downloadMod group: 'com.minecrafttas', name: 'killtherng-full', version: '2.0' // for downloadKTRNG task
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ mod_email=scribble@minecrafttas.com
 # TASmod properties
 group=com.minecrafttas
 artifact=TASmod-1.12.2
-version=Beta1-SNAPHOT
+version=Beta1-SNAPSHOT

--- a/src/main/java/com/minecrafttas/mctcommon/LanguageManager.java
+++ b/src/main/java/com/minecrafttas/mctcommon/LanguageManager.java
@@ -1,0 +1,73 @@
+package com.minecrafttas.common;
+
+import com.google.gson.Gson;
+import net.minecraft.client.resources.IResource;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.util.ResourceLocation;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class LanguageManager {
+
+    private static Set<String> modids = new HashSet<>();
+    private static final Pattern PATTERN = Pattern.compile("%(\\d+\\$)?[\\d\\.]*[df]");
+
+    public static Map<String, String> onResourceManagerReload(IResourceManager iResourceManager, List<String> languageList) {
+        HashMap<String, String> out = new HashMap<>();
+        for (String language : languageList) {
+            language = language.toLowerCase();
+            for (String modid : modids) {
+                HashMap<String, String> map = new HashMap<>();
+                if (iResourceManager.getResourceDomains().contains(modid)) {
+                    try {
+                        map = getFromResourcePack(iResourceManager, modid, language);
+                    } catch (IOException var9) {
+                    }
+                }
+                if (map.isEmpty()) {
+                    map = getFromResources(modid, language);
+                }
+                out.putAll(map);
+            }
+        }
+
+        return out;
+    }
+
+    private static HashMap<String, String> getFromResources(String resourceDomain, String language) {
+        InputStream resource = LanguageManager.class.getResourceAsStream(String.format("/assets/%s/lang/%s.json", resourceDomain, language));
+        return loadJson(resource);
+    }
+
+    private static HashMap<String, String> getFromResourcePack(IResourceManager iResourceManager, String resourceDomain, String language) throws IOException {
+        String languageFile = String.format("lang/%s.json", language);
+        HashMap<String, String> out = new HashMap<>();
+        Collection<IResource> allResources = iResourceManager.getAllResources(new ResourceLocation(resourceDomain, languageFile));
+        for (IResource iResource : allResources) {
+            InputStream inputStream = iResource.getInputStream();
+            out.putAll(loadJson(inputStream));
+        }
+        return out;
+    }
+
+    public static void registerModForLanguageManager(String modid) {
+        modids.add(modid);
+    }
+
+    private static HashMap<String, String> loadJson(InputStream inputStream) {
+        if(inputStream == null){
+            return new HashMap<String, String>();
+        }
+        Gson gson = new Gson();
+        HashMap<String, String> template = new HashMap<>();
+        HashMap<String, String> out = (HashMap<String, String>)gson.fromJson(new InputStreamReader(inputStream), template.getClass());
+        out.forEach((key, value) -> {
+            value = PATTERN.matcher(value).replaceAll("%$1s");
+        });
+        return out;
+    }
+}

--- a/src/main/java/com/minecrafttas/mctcommon/LanguageManager.java
+++ b/src/main/java/com/minecrafttas/mctcommon/LanguageManager.java
@@ -22,7 +22,6 @@ public class LanguageManager {
     private static final Pattern PATTERN = Pattern.compile("%(\\d+\\$)?[\\d\\.]*[df]");
 
     public static void onResourceManagerReload(Map<String, String> original, IResourceManager iResourceManager, List<String> languageList) {
-
         for (String language : languageList) { // Go through all loaded languages
             language = language.toLowerCase(); // Set everything to lowercase which prevents headaches in 1.10.2 and below
             for (String modid : modids) {      // Iterate through all registered modids
@@ -72,7 +71,14 @@ public class LanguageManager {
         return out;
     }
 
-    public static void registerModForLanguageManager(String modid) {
+    /**
+     * Registers your mod to be processed by the language manager<br>
+     * This will allow you to add .json and/or .lang files to assets/modid/lang<br>
+     * with en_us.lang/en_us.json (<strong>lowercase!</strong>)
+     * 
+     * @param modid The modid of your mod
+     */
+    public static void registerMod(String modid) {
         modids.add(modid);
     }
 

--- a/src/main/java/com/minecrafttas/mctcommon/LanguageManager.java
+++ b/src/main/java/com/minecrafttas/mctcommon/LanguageManager.java
@@ -1,46 +1,64 @@
 package com.minecrafttas.common;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import net.minecraft.client.resources.IResource;
 import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
+import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Pattern;
 
 public class LanguageManager {
 
     private static Set<String> modids = new HashSet<>();
+    private static final Splitter SPLITTER = Splitter.on('=').limit(2);
     private static final Pattern PATTERN = Pattern.compile("%(\\d+\\$)?[\\d\\.]*[df]");
 
-    public static Map<String, String> onResourceManagerReload(IResourceManager iResourceManager, List<String> languageList) {
-        HashMap<String, String> out = new HashMap<>();
-        for (String language : languageList) {
-            language = language.toLowerCase();
-            for (String modid : modids) {
-                HashMap<String, String> map = new HashMap<>();
+    public static void onResourceManagerReload(Map<String, String> original, IResourceManager iResourceManager, List<String> languageList) {
+
+        for (String language : languageList) { // Go through all loaded languages
+            language = language.toLowerCase(); // Set everything to lowercase which prevents headaches in 1.10.2 and below
+            for (String modid : modids) {      // Iterate through all registered modids
+                HashMap<String, String> newTranslations = new HashMap<>();
                 if (iResourceManager.getResourceDomains().contains(modid)) {
                     try {
-                        map = getFromResourcePack(iResourceManager, modid, language);
+                        newTranslations = getFromResourcePack(iResourceManager, modid, language);   // Load .json translations from resource pack
                     } catch (IOException var9) {
                     }
                 }
-                if (map.isEmpty()) {
-                    map = getFromResources(modid, language);
+                if (newTranslations.isEmpty()) {
+                    try {
+                        newTranslations = loadLang(getFromResources(modid, language, "lang")); // Load .lang files from resources
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
-                out.putAll(map);
+                if (newTranslations.isEmpty()) {
+                    newTranslations = loadJson(getFromResources(modid, language, "json")); // Load .json translations from resources
+                }
+                /**
+                 * Making this put if absent here creates the following hirarchy:
+                 * Resourcepack .lang beats
+                 * Resourcepack .json beats
+                 * Resources .lang beats
+                 * Resources .json
+                 *
+                 * Lang is preferred over json and resourcepacks are preferred over json
+                 */
+                newTranslations.forEach(original::putIfAbsent);
             }
         }
-
-        return out;
     }
 
-    private static HashMap<String, String> getFromResources(String resourceDomain, String language) {
-        InputStream resource = LanguageManager.class.getResourceAsStream(String.format("/assets/%s/lang/%s.json", resourceDomain, language));
-        return loadJson(resource);
+    private static InputStream getFromResources(String resourceDomain, String language, String fileending) {
+        return LanguageManager.class.getResourceAsStream(String.format("/assets/%s/lang/%s.%s", resourceDomain, language, fileending));
     }
 
     private static HashMap<String, String> getFromResourcePack(IResourceManager iResourceManager, String resourceDomain, String language) throws IOException {
@@ -59,15 +77,33 @@ public class LanguageManager {
     }
 
     private static HashMap<String, String> loadJson(InputStream inputStream) {
-        if(inputStream == null){
+        if (inputStream == null) {
             return new HashMap<String, String>();
         }
         Gson gson = new Gson();
         HashMap<String, String> template = new HashMap<>();
-        HashMap<String, String> out = (HashMap<String, String>)gson.fromJson(new InputStreamReader(inputStream), template.getClass());
+        HashMap<String, String> out = (HashMap<String, String>) gson.fromJson(new InputStreamReader(inputStream), template.getClass());
         out.forEach((key, value) -> {
             value = PATTERN.matcher(value).replaceAll("%$1s");
         });
+        return out;
+    }
+
+    private static HashMap<String, String> loadLang(InputStream inputStream) throws IOException {
+        HashMap<String, String> out = new HashMap<>();
+        if (inputStream == null) {
+            return out;
+        }
+        for (String string : IOUtils.readLines(inputStream, StandardCharsets.UTF_8)) {
+            if (!string.isEmpty() && string.charAt(0) != '#') {
+                String[] key_value_pair = Iterables.toArray(SPLITTER.split(string), String.class);
+                if (key_value_pair != null && key_value_pair.length == 2) {
+                    String key = key_value_pair[0];
+                    String value = PATTERN.matcher(key_value_pair[1]).replaceAll("%$1s");
+                    out.put(key, value);
+                }
+            }
+        }
         return out;
     }
 }

--- a/src/main/java/com/minecrafttas/mctcommon/mixin/MixinLocale.java
+++ b/src/main/java/com/minecrafttas/mctcommon/mixin/MixinLocale.java
@@ -19,6 +19,6 @@ public class MixinLocale {
     private Map<String, String> properties;
     @Inject(method="loadLocaleDataFiles", at = @At("RETURN"))
     private void inject_loadLocalDataFiles(IResourceManager iResourceManager, List<String> list, CallbackInfo ci){
-        properties.putAll(LanguageManager.onResourceManagerReload(iResourceManager, list));
+        LanguageManager.onResourceManagerReload(properties, iResourceManager, list);
     }
 }

--- a/src/main/java/com/minecrafttas/mctcommon/mixin/MixinLocale.java
+++ b/src/main/java/com/minecrafttas/mctcommon/mixin/MixinLocale.java
@@ -1,0 +1,24 @@
+package com.minecrafttas.common.mixin;
+
+import com.minecrafttas.common.LanguageManager;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.Locale;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+import java.util.Map;
+
+@Mixin(Locale.class)
+public class MixinLocale {
+
+    @Shadow
+    private Map<String, String> properties;
+    @Inject(method="loadLocaleDataFiles", at = @At("RETURN"))
+    private void inject_loadLocalDataFiles(IResourceManager iResourceManager, List<String> list, CallbackInfo ci){
+        properties.putAll(LanguageManager.onResourceManagerReload(iResourceManager, list));
+    }
+}

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -1,16 +1,6 @@
 package com.minecrafttas.tasmod;
 
-import static com.minecrafttas.tasmod.TASmod.LOGGER;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.minecrafttas.common.LanguageManager;
-import org.apache.logging.log4j.Level;
-import org.lwjgl.input.Keyboard;
-
 import com.minecrafttas.mctcommon.Configuration;
 import com.minecrafttas.mctcommon.Configuration.ConfigOptions;
 import com.minecrafttas.mctcommon.KeybindManager;
@@ -38,7 +28,6 @@ import com.minecrafttas.tasmod.util.Scheduler;
 import com.minecrafttas.tasmod.util.ShieldDownloader;
 import com.minecrafttas.tasmod.virtual.VirtualInput;
 import com.minecrafttas.tasmod.virtual.VirtualKeybindings;
-
 import net.fabricmc.api.ClientModInitializer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -48,6 +37,15 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.server.MinecraftServer;
+import org.apache.logging.log4j.Level;
+import org.lwjgl.input.Keyboard;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.minecrafttas.tasmod.TASmod.LOGGER;
 
 public class TASmodClient implements ClientModInitializer, EventClientInit, EventPlayerJoinedClientSide, EventOpenGui{
 
@@ -112,7 +110,7 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		}
 		config = new Configuration("TASmod configuration", new File(configDir, "tasmod.cfg"));
 		
-		LanguageManager.registerModForLanguageManager("tasmod");
+		LanguageManager.registerMod("tasmod");
 
 		// Execute /restartandplay. Load the file to start from the config. If it exists load the playback file on start.
 		String fileOnStart = config.get(ConfigOptions.FileToOpen);

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.minecrafttas.common.LanguageManager;
 import org.apache.logging.log4j.Level;
 import org.lwjgl.input.Keyboard;
 
@@ -111,6 +112,8 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		}
 		config = new Configuration("TASmod configuration", new File(configDir, "tasmod.cfg"));
 		
+		LanguageManager.registerModForLanguageManager("tasmod");
+
 		// Execute /restartandplay. Load the file to start from the config. If it exists load the playback file on start.
 		String fileOnStart = config.get(ConfigOptions.FileToOpen);
 		if (fileOnStart.isEmpty()) {

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandTickrate.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandTickrate.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 import com.minecrafttas.tasmod.TASmod;
 
+import net.minecraft.client.resources.I18n;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -29,7 +30,7 @@ public class CommandTickrate extends CommandBase {
 
 	@Override
 	public String getUsage(ICommandSender sender) {
-		return "/tickrate <ticks per second>";
+		return I18n.format("tickratechanger.tasmod.command.usage"); // "/tickrate <ticks per second>"
 	}
 
 	@Override
@@ -40,7 +41,7 @@ public class CommandTickrate extends CommandBase {
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
 		if (args.length == 0) {
-			sender.sendMessage(new TextComponentString("Current tickrate: " + TASmod.tickratechanger.ticksPerSecond));
+			sender.sendMessage(new TextComponentString( I18n.format("tickratechanger.tasmod.command.show", TASmod.tickratechanger.ticksPerSecond))); //"Current tickrate: "
 			return;
 		}
 		float tickrate;

--- a/src/main/resources/assets/tasmod/lang/en_us.json
+++ b/src/main/resources/assets/tasmod/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "tickratechanger.tasmod.command.show": "Current tickrate: %s",
+  "tickratechanger.tasmod.command.usage": "/tickrate <ticks per second>"
+}

--- a/src/main/resources/mctcommon.mixin.json
+++ b/src/main/resources/mctcommon.mixin.json
@@ -13,6 +13,7 @@
     	"MixinMinecraft",
     	"MixinNetHandlerPlayClient",
     	"MixinWorldClient",
-    	"MixinEntityRenderer"
+    	"MixinEntityRenderer",
+        "MixinLocale"
 	]
 }


### PR DESCRIPTION

First step for #174 is creating a way to load custom language files to legacy fabric.

## Registering
I can seem to find a "all loaded modids" function in the FabricLoader so now you have to register your modid yourself...
```java
LanguageManager.registerMod("modid");
```
Not the most elegant solution, but a good one if you want to reuse these classes in your mod...

## Json support
I've learnt my lesson and maintaining .json and .lang files both at the same time is a *nightmare*. So why don't I just downpatch the json lang files from 1.14?

Even better, both formats are supported and the hirarchy is as follows:
1. Resourcepack, .lang
2. Resourcepack, .json
3. Resource, .lang
4. Resource, .json

Lang files are still more preferred in the hirarchy, so that old resourcepacks with .lang still work, but in 99% of cases you can just use .json.

As to why I'm still supporting .lang? Well for LoTAS I created seperate lang files... so if LoTAS is ever ported to legacyfabric on the fly, you can be sure that this will work as well.

## Lowercase
All lang files (Except Resourcepack .lang) are now being lowercased... This doesn't make much sense in 1.12.2 but in 1.10, all lang files had to be in en_US.lang... So to prevent future headaches I made everything like 1.14.