### PR TITLE
[VirtualInput] Fixed scroll wheel not updating correctly

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
@@ -143,7 +143,7 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 			 * ...but scrollWheel, cursorX or cursorY are different.
 			 * Without this, the scrollWheel would only work if a mouse button is pressed at the same time. 
 			 */
-			if(!equals(nextMouse)) {
+			if(!equals(nextMouse) || scrollWheel != 0) {
 				reference.add(new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, nextMouse.scrollWheel, nextMouse.cursorX, nextMouse.cursorY));
 			}
 			return;

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
@@ -142,6 +142,10 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 			/*
 			 * ...but scrollWheel, cursorX or cursorY are different.
 			 * Without this, the scrollWheel would only work if a mouse button is pressed at the same time. 
+			 * 
+			 * (#198) Additionally, we also need to check if the scroll wheel is not 0.
+			 * Otherwise, repeated usage of the scrollWheel will result in #equals being true,
+			 * which doesn't trigger the if clause like it should.
 			 */
 			if(!equals(nextMouse) || scrollWheel != 0) {
 				reference.add(new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, nextMouse.scrollWheel, nextMouse.cursorX, nextMouse.cursorY));

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
@@ -12,7 +12,8 @@ import com.minecrafttas.tasmod.virtual.event.VirtualEvent;
  * Base class for {@link VirtualKeyboard} and {@link VirtualMouse}<br>
  * <br>
  * Contains the shared code for keeping track of which buttons are pressed.<br>
- * This works by storing the keycodes of the buttons in a set, as keycodes are supposed to be unique<br>
+ * This works by storing the keycodes of the buttons in a set, as keycodes are
+ * supposed to be unique<br>
  * <br>
  * Generating {@link VirtualEvent}s is handled in the child classes.
  *
@@ -20,90 +21,95 @@ import com.minecrafttas.tasmod.virtual.event.VirtualEvent;
  */
 public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends Subtickable<T> implements Serializable {
 
-    /**
-     * The list of keycodes that are currently pressed on this peripheral.
-     */
-    protected final Set<Integer> pressedKeys;
-	
-    /**
-     * Creates a VirtualPeripheral
-     * @param pressedKeys The {@link #pressedKeys}
-     * @param subtickList The {@link #subtickList}
-     * @param ignoreFirstUpdate The {@link #ignoreFirstUpdate} state
-     */
-    protected VirtualPeripheral(Set<Integer> pressedKeys, List<T> subtickList, boolean ignoreFirstUpdate) {
-    	super(subtickList, ignoreFirstUpdate);
-        this.pressedKeys = pressedKeys;
-    }
+	/**
+	 * The list of keycodes that are currently pressed on this peripheral.
+	 */
+	protected final Set<Integer> pressedKeys;
 
-    /**
-     * Set the specified keycode to pressed
-     * @param keycode The keycode to check
-     * @param keystate The keystate of the keycode
-     */
-    protected void setPressed(int keycode, boolean keystate) {
-		if (VirtualKeybindings.isKeyCodeAlwaysBlocked(keycode)) { //TODO Maybe a better system?
+	/**
+	 * Creates a VirtualPeripheral
+	 * 
+	 * @param pressedKeys       The {@link #pressedKeys}
+	 * @param subtickList       The {@link #subtickList}
+	 * @param ignoreFirstUpdate The {@link #ignoreFirstUpdate} state
+	 */
+	protected VirtualPeripheral(Set<Integer> pressedKeys, List<T> subtickList, boolean ignoreFirstUpdate) {
+		super(subtickList, ignoreFirstUpdate);
+		this.pressedKeys = pressedKeys;
+	}
+
+	/**
+	 * Set the specified keycode to pressed
+	 * 
+	 * @param keycode  The keycode to check
+	 * @param keystate The keystate of the keycode
+	 */
+	protected void setPressed(int keycode, boolean keystate) {
+		if (VirtualKeybindings.isKeyCodeAlwaysBlocked(keycode)) { // TODO Maybe a better system?
 			return;
 		}
-        if (keystate)
-            pressedKeys.add(keycode);
-        else
-            pressedKeys.remove(keycode);
-    }
-    
-    /**
-     * Set the specified keyname to pressed
-     * @param keyname The keyname to check
-     * @param keystate The keystate of the keyname
-     */
-    public void setPressed(String keyname, boolean keystate) {
-        Integer keycode = VirtualKey.getKeycode(keyname);
-        if (keycode != null) {
-            setPressed(keycode, keystate);
-        }
-    }
+		if (keystate)
+			pressedKeys.add(keycode);
+		else
+			pressedKeys.remove(keycode);
+	}
 
-    /**
-     * @return A list of all currently pressed keynames
-     */
-    public List<String> getCurrentPresses() {
-        List<String> out = new ArrayList<>();
-        pressedKeys.forEach(keycode -> {
-            out.add(VirtualKey.getName(keycode));
-        });
-        return out;
-    }
+	/**
+	 * Set the specified keyname to pressed
+	 * 
+	 * @param keyname  The keyname to check
+	 * @param keystate The keystate of the keyname
+	 */
+	public void setPressed(String keyname, boolean keystate) {
+		Integer keycode = VirtualKey.getKeycode(keyname);
+		if (keycode != null) {
+			setPressed(keycode, keystate);
+		}
+	}
 
-    @Override
-    public String toString() {
-        return String.join(",", getCurrentPresses());
-    }
+	/**
+	 * @return A list of all currently pressed keynames
+	 */
+	public List<String> getCurrentPresses() {
+		List<String> out = new ArrayList<>();
+		pressedKeys.forEach(keycode -> {
+			out.add(VirtualKey.getName(keycode));
+		});
+		return out;
+	}
 
-    /**
-     * @return An immutable set of pressed keycodes
-     */
+	@Override
+	public String toString() {
+		return String.join(",", getCurrentPresses());
+	}
+
+	/**
+	 * @return An immutable set of pressed keycodes
+	 */
 	public Set<Integer> getPressedKeys() {
 		return ImmutableSet.copyOf(pressedKeys);
 	}
 
 	/**
 	 * If the key is available in {@link #pressedKeys}
+	 * 
 	 * @param keycode The keycode in question
 	 * @return If the key is pressed
 	 */
 	public boolean isKeyDown(int keycode) {
 		return pressedKeys.contains(keycode);
 	}
-	
+
 	/**
 	 * If the key is available in {@link #pressedKeys}
+	 * 
 	 * @param keyname The keyname in question
 	 * @return If the key is pressed
 	 */
 	public boolean isKeyDown(String keyname) {
 		return pressedKeys.contains(VirtualKey.getKeycode(keyname));
 	}
-	
+
 	/**
 	 * Clears pressed keys and subticks
 	 */
@@ -112,13 +118,13 @@ public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends 
 		pressedKeys.clear();
 		super.clear();
 	}
-	
+
 	@Override
 	public boolean equals(Object obj) {
-		if(obj instanceof VirtualPeripheral) {
+		if (obj instanceof VirtualPeripheral) {
 			VirtualPeripheral<?> peripheral = (VirtualPeripheral<?>) obj;
 			for (Integer keycode : pressedKeys) {
-				if(!peripheral.pressedKeys.contains(keycode)) {
+				if (!peripheral.pressedKeys.contains(keycode)) {
 					return false;
 				}
 			}
@@ -126,11 +132,13 @@ public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends 
 		}
 		return super.equals(obj);
 	}
-	
-    /**
-     * Copies the data from another virtual peripheral into this peripheral without creating a new object.
-     * @param peripheral The peripheral to move from
-     */
+
+	/**
+	 * Copies the data from another virtual peripheral into this peripheral without
+	 * creating a new object.
+	 * 
+	 * @param peripheral The peripheral to move from
+	 */
 	protected void copyFrom(T peripheral) {
 		this.pressedKeys.clear();
 		this.pressedKeys.addAll(peripheral.pressedKeys);

--- a/src/main/resources/tasmod.mixin.json
+++ b/src/main/resources/tasmod.mixin.json
@@ -43,7 +43,7 @@
 		
 		//Playbackhooks
 		"playbackhooks.MixinMinecraft",
-        "playbackhooks.MixinEntityRenderer",
+		"playbackhooks.MixinEntityRenderer",
 		"playbackhooks.MixinGuiScreen",
 		"playbackhooks.MixinGameSettings",
 		"playbackhooks.MixinGuiChat",

--- a/src/test/java/tasmod/virtual/VirtualMouseTest.java
+++ b/src/test/java/tasmod/virtual/VirtualMouseTest.java
@@ -291,15 +291,15 @@ class VirtualMouseTest {
     }
     
     /**
-     * Tests 2 updates having the same value. Should return no additional button events
+     * Tests 2 updates having the same value and the scroll wheel is 0. Should return no additional button events
      */
     @Test
     void testSameUpdate() {
     	VirtualMouse unpressed = new VirtualMouse();
     	
     	VirtualMouse pressed = new VirtualMouse();
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
+    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
+    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
     	
     	// Load actual with the events
     	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
@@ -307,14 +307,15 @@ class VirtualMouseTest {
     	
     	// Load expected
     	List<VirtualMouseEvent> expected = Arrays.asList(
-    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 15, 10, 12) // Should only have one keyboard event
+    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 0, 10, 12) // Should only have one keyboard event
     			); 
     	
     	assertIterableEquals(expected, actual);
     }
     
+    
     /**
-     * Tests 2 updates having the same pressed keys, but scrollWheel is different
+     * Tests 2 updates having the same pressed keys, but scrollWheel != 0
      */
     @Test
     void testScrollWheelDifferent() {
@@ -322,7 +323,7 @@ class VirtualMouseTest {
     	
     	VirtualMouse pressed = new VirtualMouse();
     	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
-    	pressed.update(VirtualKey.LC.getKeycode(), true, -30, 10, 12);
+    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
     	
     	// Load actual with the events
     	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
@@ -331,7 +332,7 @@ class VirtualMouseTest {
     	// Load expected
     	List<VirtualMouseEvent> expected = Arrays.asList(
     			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 15, 10, 12),
-    			new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, -30, 10, 12) // Adds an additional "MOUSEMOVED" event with the scroll wheel
+    			new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 15, 10, 12) // Adds an additional "MOUSEMOVED" event with the scroll wheel
     			);
     	
     	assertIterableEquals(expected, actual);
@@ -345,8 +346,8 @@ class VirtualMouseTest {
     	VirtualMouse unpressed = new VirtualMouse();
     	
     	VirtualMouse pressed = new VirtualMouse();
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 11, 12);
+    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
+    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 11, 12);
     	
     	// Load actual with the events
     	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
@@ -354,8 +355,8 @@ class VirtualMouseTest {
     	
     	// Load expected
     	List<VirtualMouseEvent> expected = Arrays.asList(
-    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 15, 10, 12),
-    			new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 15, 11, 12) // Adds an additional "MOUSEMOVED" event with the cursorX
+    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 0, 10, 12),
+    			new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 0, 11, 12) // Adds an additional "MOUSEMOVED" event with the cursorX
     			);
     	
     	assertIterableEquals(expected, actual);
@@ -369,8 +370,8 @@ class VirtualMouseTest {
     	VirtualMouse unpressed = new VirtualMouse();
     	
     	VirtualMouse pressed = new VirtualMouse();
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 120);
+    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
+    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 120);
     	
     	// Load actual with the events
     	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
@@ -378,8 +379,8 @@ class VirtualMouseTest {
     	
     	// Load expected
     	List<VirtualMouseEvent> expected = Arrays.asList(
-    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 15, 10, 12),
-    			new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 15, 10, 120) // Adds an additional "MOUSEMOVED" event with the cursorY
+    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 0, 10, 12),
+    			new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 0, 10, 120) // Adds an additional "MOUSEMOVED" event with the cursorY
     			);
     	
     	assertIterableEquals(expected, actual);


### PR DESCRIPTION
An extra event is now created in getDifference, not only when the mice don't equal but when the scroll wheel doesn't equal 0
- **Fixed indentation in some files**
