### PR TITLE
[MCTCommon/Events] Improve event firing and listening

### DIFF
--- a/src/main/java/com/minecrafttas/mctcommon/events/EventClient.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventClient.java
@@ -8,6 +8,11 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.GuiScreen;
 
+/**
+ * Contains all events fired on the client side
+ *
+ * @author Scribble
+ */
 public interface EventClient {
 	
 	/**
@@ -180,7 +185,7 @@ public interface EventClient {
 
 		/**
 		 * Fired when a different player other than yourself joins a server or a world
-		 * @param player The game profile of the player that joins the server or the world
+		 * @param profile The game profile of the player that joins the server or the world
 		 */
 		public void onOtherPlayerJoinedClientSide(GameProfile profile);
 	}

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventClient.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventClient.java
@@ -1,6 +1,5 @@
 package com.minecrafttas.mctcommon.events;
 
-import com.minecrafttas.mctcommon.MCTCommon;
 import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
 import com.minecrafttas.mctcommon.server.Client;
 import com.mojang.authlib.GameProfile;
@@ -16,6 +15,7 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventOpenGui extends EventBase {
 		
 		/**
@@ -24,20 +24,6 @@ public interface EventClient {
 		 * @return
 		 */
 		public GuiScreen onOpenGui(GuiScreen gui);
-		
-		public static GuiScreen fireOpenGuiEvent(GuiScreen gui) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing OpenGuiEvent");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventOpenGui) {
-					EventOpenGui event = (EventOpenGui) eventListener;
-					GuiScreen newGui = event.onOpenGui(gui);
-					if(newGui != gui) {
-						return newGui;
-					}
-				}
-			}
-			return gui;
-		}
 	}
 	
 	/**
@@ -45,22 +31,13 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventLaunchIntegratedServer extends EventBase {
 		
 		/**
 		 * Fired when the integrated server is launched
 		 */
 		public void onLaunchIntegratedServer();
-		
-		public static void fireOnLaunchIntegratedServer() {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing LaunchIntegratedServer");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventLaunchIntegratedServer) {
-					EventLaunchIntegratedServer event = (EventLaunchIntegratedServer) eventListener;
-					event.onLaunchIntegratedServer();
-				}
-			}
-		}
 	}
 
 	/**
@@ -68,22 +45,13 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventDoneLoadingWorld extends EventBase {
 
 		/**
 		 * Fired when the world is done loading, before the player joined the world
 		 */
 		public void onDoneLoadingWorld();
-		
-		public static void fireOnDoneLoadingWorld() {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing DoneLoadingWorld");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventDoneLoadingWorld) {
-					EventDoneLoadingWorld event = (EventDoneLoadingWorld) eventListener;
-					event.onDoneLoadingWorld();
-				}
-			}
-		}
 	}
 	
 	/**
@@ -91,6 +59,7 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventClientTick extends EventBase {
 		
 		/**
@@ -98,15 +67,6 @@ public interface EventClient {
 		 * @param mc The ticking Minecraft instance
 		 */
 		public void onClientTick(Minecraft mc);
-		
-		public static void fireOnClientTick(Minecraft mc) {
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventClientTick) {
-					EventClientTick event = (EventClientTick) eventListener;
-					event.onClientTick(mc);
-				}
-			}
-		}
 	}
 	
 	/**
@@ -114,6 +74,7 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventClientInit extends EventBase {
 		
 		/**
@@ -121,16 +82,6 @@ public interface EventClient {
 		 * @param mc The initialized Minecraft instance
 		 */
 		public void onClientInit(Minecraft mc);
-		
-		public static void fireOnClientInit(Minecraft mc) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing ClientInit");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventClientInit) {
-					EventClientInit event = (EventClientInit) eventListener;
-					event.onClientInit(mc);
-				}
-			}
-		}
 	}
 
 	/**
@@ -138,6 +89,7 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventClientGameLoop extends EventBase {
 		
 		/**
@@ -145,15 +97,6 @@ public interface EventClient {
 		 * @param mc The Minecraft instance that is looping
 		 */
 		public void onRunClientGameLoop(Minecraft mc);
-		
-		public static void fireOnClientGameLoop(Minecraft mc) {
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventClientGameLoop) {
-					EventClientGameLoop event = (EventClientGameLoop) eventListener;
-					event.onRunClientGameLoop(mc);
-				}
-			}
-		}
 	}
 
 	/**
@@ -161,6 +104,7 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventCamera extends EventBase {
 		
 		/**
@@ -169,19 +113,6 @@ public interface EventClient {
 		 * @return The changed camera data. Can be changed during the event
 		 */
 		public CameraData onCameraEvent(CameraData dataIn);
-		
-		public static CameraData fireCameraEvent(CameraData dataIn) {
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventCamera) {
-					EventCamera event = (EventCamera) eventListener;
-					CameraData data = event.onCameraEvent(dataIn);
-					if(!data.equals(dataIn)) {
-						return data;
-					}
-				}
-			}
-			return dataIn;
-		}
 		
 		public static class CameraData{
 			public float pitch;
@@ -214,6 +145,7 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventPlayerLeaveClientSide extends EventBase {
 		
 		/**
@@ -221,16 +153,6 @@ public interface EventClient {
 		 * @param player The player that leaves the server or the world
 		 */
 		public void onPlayerLeaveClientSide(EntityPlayerSP player);
-		
-		public static void firePlayerLeaveClientSide(EntityPlayerSP player) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing PlayerLeaveClientSideEvent");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventPlayerLeaveClientSide) {
-					EventPlayerLeaveClientSide event = (EventPlayerLeaveClientSide) eventListener;
-					event.onPlayerLeaveClientSide(player);
-				}
-			}
-		}
 	}
 	
 	/**
@@ -238,6 +160,7 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventPlayerJoinedClientSide extends EventBase {
 
 		/**
@@ -245,17 +168,6 @@ public interface EventClient {
 		 * @param player The player that joins the server or the world
 		 */
 		public void onPlayerJoinedClientSide(EntityPlayerSP player);
-		
-		public static void firePlayerJoinedClientSide(EntityPlayerSP player) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing PlayerJoinedClientSide");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventPlayerJoinedClientSide) {
-					EventPlayerJoinedClientSide event = (EventPlayerJoinedClientSide) eventListener;
-					event.onPlayerJoinedClientSide(player);
-				}
-			}
-		}
-
 	}
 
 	/**
@@ -263,6 +175,7 @@ public interface EventClient {
 	 * @author Scribble
 	 *
 	 */
+	@FunctionalInterface
 	public static interface EventOtherPlayerJoinedClientSide extends EventBase {
 
 		/**
@@ -270,23 +183,12 @@ public interface EventClient {
 		 * @param player The game profile of the player that joins the server or the world
 		 */
 		public void onOtherPlayerJoinedClientSide(GameProfile profile);
-		
-
-		public static void fireOtherPlayerJoinedClientSide(GameProfile profile) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing OtherPlayerJoinedClientSide");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventOtherPlayerJoinedClientSide) {
-					EventOtherPlayerJoinedClientSide event = (EventOtherPlayerJoinedClientSide) eventListener;
-					event.onOtherPlayerJoinedClientSide(profile);
-				}
-			}
-		}
-		
 	}
 	
 	/**
 	 * Fired when the connection to the custom server was closed on the client side.
 	 */
+	@FunctionalInterface
 	public static interface EventDisconnectClient extends EventBase {
 		
 		/**
@@ -294,15 +196,5 @@ public interface EventClient {
 		 * @param client The client that is disconnecting
 		 */
 		public void onDisconnectClient(Client client);
-		
-		public static void fireDisconnectClient(Client client) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing EventDisconnectClient");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventDisconnectClient) {
-					EventDisconnectClient event = (EventDisconnectClient) eventListener;
-					event.onDisconnectClient(client);
-				}
-			}
-		}
 	}
 }

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventException.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventException.java
@@ -1,0 +1,16 @@
+package com.minecrafttas.mctcommon.events;
+
+public class EventException extends RuntimeException {
+
+    public EventException(String message, Class<? extends EventListenerRegistry.EventBase> eventClass) {
+        super(eventClass.getName() + ": " + message);
+    }
+
+    public EventException(String message, Class<? extends EventListenerRegistry.EventBase> eventClass, Throwable cause) {
+        super(eventClass.getName() + ": " + message, cause);
+    }
+
+    public EventException(Class<? extends EventListenerRegistry.EventBase> eventClass, Throwable cause) {
+        super(eventClass.getName(), cause);
+    }
+}

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
@@ -1,72 +1,172 @@
 package com.minecrafttas.mctcommon.events;
 
+import org.apache.commons.lang3.ClassUtils;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class EventListenerRegistry {
-	
-	private static HashMap<Class<?>, ArrayList<EventBase>> EVENTLISTENER_REGISTRY = new HashMap<>();
-	
-	
-	public static void register(EventBase eventListener) {
-		if (eventListener == null) {
-			throw new NullPointerException("Tried to register a packethandler with value null");
-		}
-		for (Class<?> type : eventListener.getClass().getInterfaces()) {
-			if(EventBase.class.isAssignableFrom(type)) {
-				ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.putIfAbsent(type, new ArrayList<>());
-				if(registryList==null) {
-					registryList = EVENTLISTENER_REGISTRY.get(type);
-				}
-				registryList.add(eventListener);
-			}
-		}
-	}
-	
-	public static void unregister(EventBase eventListener) {
-		if (eventListener == null) {
-			throw new NullPointerException("Tried to unregister a packethandler with value null");
-		}
-		EVENTLISTENER_REGISTRY.remove(eventListener);
-	}
-	
-	public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass) throws Exception {
-		return fireEvent(eventClass, new Object[] {});
-	}
-	
-	public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass, Object... eventParams) throws Exception {
-		ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.get(eventClass);
-		if(registryList == null) {
-			throw new Exception(String.format("The event {} has not been registered yet", eventClass));
-		}
-		
-		Method methodToCheck = getEventMethod(eventClass);
-		
-		for (EventBase eventListener : registryList) {
-			Method[] methodsInListener = eventListener.getClass().getDeclaredMethods();
-			
-			for (Method method : methodsInListener) {
-				if(method.getName().equals(methodToCheck.getName())) {
-					method.setAccessible(true);
-					return method.invoke(eventListener, eventParams);
-				}
-			}
-		}
-		throw new Exception(String.format("The event {} has not been registered yet", eventClass));
-	}
-	
-	public static Method getEventMethod(Class<? extends EventListenerRegistry.EventBase> eventClass) throws Exception {
-		Method[] test = eventClass.getDeclaredMethods();
-		if(test.length != 1) {
-			throw new Exception("The event method is not properly defined. Only one method is allowed inside of an event");
-		}
-		
-		return test[0];
-	}
-	
-	public static interface EventBase {
-		
-	}
+
+    /**
+     * Eventlistener Registry.<br>
+     * <br>
+     * Consists of multiple lists seperated by event types.<br>
+     * If it were a single ArrayList, firing an event means that you'd have to unnecessarily iterate over the entire list,<br>
+     * to find the correct events.<br>
+     * <br>
+     * With multiple lists like this, you iterate only over the objects, that have the correct event applied.
+     */
+    private static final HashMap<Class<?>, ArrayList<EventBase>> EVENTLISTENER_REGISTRY = new HashMap<>();
+
+
+    public static void register(EventBase eventListener) {
+        if (eventListener == null) {
+            throw new NullPointerException("Tried to register a packethandler with value null");
+        }
+        for (Class<?> type : eventListener.getClass().getInterfaces()) {
+            if (EventBase.class.isAssignableFrom(type)) {
+
+                // If a new event type is being registered, add a new arraylist
+                ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.putIfAbsent(type, new ArrayList<>());
+                if (registryList == null) {
+                    registryList = EVENTLISTENER_REGISTRY.get(type);
+                }
+                registryList.add(eventListener);
+            }
+        }
+    }
+
+    public static void unregister(EventBase eventListener) {
+        if (eventListener == null) {
+            throw new NullPointerException("Tried to unregister a packethandler with value null");
+        }
+        for (Class<?> type : eventListener.getClass().getInterfaces()) {
+            if (EventBase.class.isAssignableFrom(type)) {
+                ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.get(type);
+                if (registryList != null) {
+                    registryList.remove(eventListener);
+
+                    if (registryList.isEmpty()) {
+                        EVENTLISTENER_REGISTRY.remove(type);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Fires an event without parameters
+     *
+     * @param eventClass The event class to fire e.g. EventClientInit.class
+     * @return The result of the event, might be null if the event returns nothing
+     */
+    public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass) {
+        return fireEvent(eventClass, new Object[]{});
+    }
+
+    /**
+     * Fires an event with parameters
+     *
+     * @param eventClass  The event class to fire e.g. EventClientInit.class
+     * @param eventParams List of parameters for the event. Number of arguments and types have to match.
+     * @return The result of the event, might be null if the event returns nothing
+     */
+    public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass, Object... eventParams) {
+        ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.get(eventClass);
+        if (registryList == null) {
+            throw new EventException("The event has not been registered yet", eventClass);
+        }
+
+        EventException toThrow = null;
+
+        Method methodToCheck = getEventMethod(eventClass);
+
+        Object returnValue = null;
+        for (EventBase eventListener : registryList) {
+            Method[] methodsInListener = eventListener.getClass().getDeclaredMethods();
+
+            for (Method method : methodsInListener) {
+
+                if (!checkName(method, methodToCheck.getName())) {
+                    continue;
+                }
+
+                if (!checkLength(method, eventParams)) {
+                    toThrow = new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass);
+                    continue;
+                }
+
+                if (checkTypes(method, eventParams)) {
+                    toThrow = null;
+                    method.setAccessible(true);
+                    try {
+                        returnValue = method.invoke(eventListener, eventParams);
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        throw new EventException(eventClass, e);
+                    } catch (IllegalArgumentException e) {
+                        throw new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass, e);
+                    }
+                } else {
+                    toThrow = new EventException("Event seems to be fired with the wrong parameter types or in the wrong order", eventClass);
+                }
+            }
+        }
+
+        if (toThrow != null) {
+            throw toThrow;
+        }
+
+        return returnValue;
+    }
+
+    private static Method getEventMethod(Class<? extends EventListenerRegistry.EventBase> eventClass) {
+        Method[] test = eventClass.getDeclaredMethods();
+        if (test.length != 1) {
+            throw new EventException("The event method is not properly defined. Only one method is allowed inside of an event", eventClass);
+        }
+
+        return test[0];
+    }
+
+    private static boolean checkName(Method method, String name) {
+        return method.getName().equals(name);
+    }
+
+    private static boolean checkLength(Method method, Object... parameters) {
+        return method.getParameterCount() == parameters.length;
+    }
+
+    private static boolean checkTypes(Method method, Object... parameters) {
+        Class<?>[] methodParameterTypes = ClassUtils.primitivesToWrappers(method.getParameterTypes());
+        Class<?>[] eventParameterTypes = getParameterTypes(parameters);
+
+        for (int i = 0; i < methodParameterTypes.length; i++) {
+            Class<?> paramName = methodParameterTypes[i];
+            Class<?> eventName = eventParameterTypes[i];
+            if (!paramName.equals(eventName)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Class<?>[] getParameterTypes(Object... parameters) {
+        Class<?>[] out = new Class[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            out[i] = parameters[i].getClass();
+        }
+        return out;
+    }
+
+    /**
+     * Removes all registry entries
+     */
+    public static void clear() {
+        EVENTLISTENER_REGISTRY.clear();
+    }
+
+    public interface EventBase {
+    }
 }

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
@@ -1,17 +1,28 @@
 package com.minecrafttas.mctcommon.events;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 
 public class EventListenerRegistry {
 	
-	private static ArrayList<EventBase> EVENTLISTENER_REGISTRY = new ArrayList<>();
+	private static HashMap<Class<?>, ArrayList<EventBase>> EVENTLISTENER_REGISTRY = new HashMap<>();
 	
 	
 	public static void register(EventBase eventListener) {
 		if (eventListener == null) {
 			throw new NullPointerException("Tried to register a packethandler with value null");
 		}
-		EVENTLISTENER_REGISTRY.add(eventListener);
+		for (Class<?> type : eventListener.getClass().getInterfaces()) {
+			if(EventBase.class.isAssignableFrom(type)) {
+				ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.putIfAbsent(type, new ArrayList<>());
+				if(registryList==null) {
+					registryList = EVENTLISTENER_REGISTRY.get(type);
+				}
+				registryList.add(eventListener);
+			}
+		}
 	}
 	
 	public static void unregister(EventBase eventListener) {
@@ -21,12 +32,41 @@ public class EventListenerRegistry {
 		EVENTLISTENER_REGISTRY.remove(eventListener);
 	}
 	
+	public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass) throws Exception {
+		return fireEvent(eventClass, new Object[] {});
+	}
 	
-	public static ArrayList<EventBase> getEventListeners(){
-		return EVENTLISTENER_REGISTRY;
+	public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass, Object... eventParams) throws Exception {
+		ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.get(eventClass);
+		if(registryList == null) {
+			throw new Exception(String.format("The event {} has not been registered yet", eventClass));
+		}
+		
+		Method methodToCheck = getEventMethod(eventClass);
+		
+		for (EventBase eventListener : registryList) {
+			Method[] methodsInListener = eventListener.getClass().getDeclaredMethods();
+			
+			for (Method method : methodsInListener) {
+				if(method.getName().equals(methodToCheck.getName())) {
+					method.setAccessible(true);
+					return method.invoke(eventListener, eventParams);
+				}
+			}
+		}
+		throw new Exception(String.format("The event {} has not been registered yet", eventClass));
+	}
+	
+	public static Method getEventMethod(Class<? extends EventListenerRegistry.EventBase> eventClass) throws Exception {
+		Method[] test = eventClass.getDeclaredMethods();
+		if(test.length != 1) {
+			throw new Exception("The event method is not properly defined. Only one method is allowed inside of an event");
+		}
+		
+		return test[0];
 	}
 	
 	public static interface EventBase {
-
+		
 	}
 }

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventServer.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventServer.java
@@ -1,19 +1,22 @@
 package com.minecrafttas.mctcommon.events;
 
-import com.minecrafttas.mctcommon.MCTCommon;
 import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
 import com.minecrafttas.mctcommon.server.Client;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 
+/**
+ * Contains all events fired on the server side
+ *
+ * @author Scribble
+ */
 public interface EventServer {
 
 	/**
 	 * Fired, when the server is initialised, for both integrated and dedicated server.
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventServerInit extends EventBase {
 
 		/**
@@ -21,23 +24,12 @@ public interface EventServer {
 		 * @param server The server 
 		 */
 		public void onServerInit(MinecraftServer server);
-
-		public static void fireServerStartEvent(MinecraftServer server) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing ServerStartEvent");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if (eventListener instanceof EventServerInit) {
-					EventServerInit event = (EventServerInit) eventListener;
-					event.onServerInit(server);
-				}
-			}
-		}
 	}
 	
 	/**
 	 * Fired when the server ticks.
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventServerTick extends EventBase {
 		
 		/**
@@ -45,22 +37,12 @@ public interface EventServer {
 		 * @param server The ticking server
 		 */
 		public void onServerTick(MinecraftServer server);
-
-		public static void fireOnServerTick(MinecraftServer server) {
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if (eventListener instanceof EventServerTick) {
-					EventServerTick event = (EventServerTick) eventListener;
-					event.onServerTick(server);
-				}
-			}
-		}
 	}
 
 	/**
 	 * Fired when the server is about to stop
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventServerStop extends EventBase {
 
 		/**
@@ -71,61 +53,37 @@ public interface EventServer {
 		 * @param server The stopping server
 		 */
 		public void onServerStop(MinecraftServer server);
-
-		public static void fireOnServerStop(MinecraftServer server) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing ServerStopEvent");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if (eventListener instanceof EventServerStop) {
-					EventServerStop event = (EventServerStop) eventListener;
-					event.onServerStop(server);
-				}
-			}
-		}
 	}
-
 
 	/**
 	 * Fired on a server game loop, which is independent from ticks
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventServerGameLoop extends EventBase {
 		/**
 		 * Fired on a server game loop, which is independent from ticks
 		 * @param server The server this event is fired on
 		 */
 		public void onRunServerGameLoop(MinecraftServer server);
-
-		public static void fireOnServerGameLoop(MinecraftServer server) {
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if (eventListener instanceof EventServerGameLoop) {
-					EventServerGameLoop event = (EventServerGameLoop) eventListener;
-					event.onRunServerGameLoop(server);
-				}
-			}
-		}
 	}
 
+	/**
+	 * Fired on the server side when a player joins
+	 */
+	@FunctionalInterface
 	public static interface EventPlayerJoinedServerSide extends EventBase {
 
+		/**
+		 * Fired when a player joins on the server side
+		 * @param player The player that is joining
+		 */
 		public void onPlayerJoinedServerSide(EntityPlayerMP player);
-
-		public static void firePlayerJoinedServerSide(EntityPlayerMP player) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing PlayerJoinedServerSide");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if (eventListener instanceof EventPlayerJoinedServerSide) {
-					EventPlayerJoinedServerSide event = (EventPlayerJoinedServerSide) eventListener;
-					event.onPlayerJoinedServerSide(player);
-				}
-			}
-		}
 	}
 	
 	/**
 	 * Fired when a player leaves the server.
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventPlayerLeaveServerSide extends EventBase {
 
 		/**
@@ -133,21 +91,12 @@ public interface EventServer {
 		 * @param player The player that is leaving
 		 */
 		public void onPlayerLeaveServerSide(EntityPlayerMP player);
-
-		public static void firePlayerLeaveServerSide(EntityPlayerMP player) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing PlayerLeaveServerSideEvent");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if (eventListener instanceof EventPlayerLeaveServerSide) {
-					EventPlayerLeaveServerSide event = (EventPlayerLeaveServerSide) eventListener;
-					event.onPlayerLeaveServerSide(player);
-				}
-			}
-		}
 	}
 	
 	/**
 	 * Fired when  authentication was successful on the server side
 	 */
+	@FunctionalInterface
 	public static interface EventClientCompleteAuthentication extends EventBase {
 		
 		/**
@@ -155,21 +104,12 @@ public interface EventServer {
 		 * @param username The username of the client that is connecting
 		 */
 		public void onClientCompleteAuthentication(String username);
-		
-		public static void fireClientCompleteAuthentication(String username) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing ClientCompleteAuthenticationEvent");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if (eventListener instanceof EventClientCompleteAuthentication) {
-					EventClientCompleteAuthentication event = (EventClientCompleteAuthentication) eventListener;
-					event.onClientCompleteAuthentication(username);
-				}
-			}
-		}
 	}
 	
 	/**
 	 * Fired when the connection to the custom server was closed on the server side.
 	 */
+	@FunctionalInterface
 	public static interface EventDisconnectServer extends EventBase {
 		
 		/**
@@ -177,15 +117,5 @@ public interface EventServer {
 		 * @param client The client that is disconnecting
 		 */
 		public void onDisconnectServer(Client client);
-		
-		public static void fireDisconnectServer(Client client) {
-			MCTCommon.LOGGER.trace(MCTCommon.Event, "Firing CustomServerClientDisconnect");
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventDisconnectServer) {
-					EventDisconnectServer event = (EventDisconnectServer) eventListener;
-					event.onDisconnectServer(client);
-				}
-			}
-		}
 	}
 }

--- a/src/main/java/com/minecrafttas/mctcommon/mixin/MixinMinecraft.java
+++ b/src/main/java/com/minecrafttas/mctcommon/mixin/MixinMinecraft.java
@@ -1,5 +1,6 @@
 package com.minecrafttas.mctcommon.mixin;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -20,38 +21,38 @@ import net.minecraft.client.gui.GuiScreen;
 
 @Mixin(Minecraft.class)
 public class MixinMinecraft {
-	
-	@Inject(method = "init", at = @At(value = "RETURN"))
-	public void inject_init(CallbackInfo ci) {
-		EventClientInit.fireOnClientInit((Minecraft)(Object)this);
-	}
-	
-	@Inject(method = "runGameLoop", at = @At(value = "HEAD"))
-	public void inject_runGameLoop(CallbackInfo ci) {
-		EventClientGameLoop.fireOnClientGameLoop((Minecraft)(Object)this);
-	}
-	
-	@Inject(method = "runTick", at = @At("HEAD"))
-	public void inject_runTick(CallbackInfo ci) {
-		EventClientTick.fireOnClientTick((Minecraft)(Object)this);
-	}
-	
-	@Inject(method = "launchIntegratedServer", at = @At("HEAD"))
-	public void inject_launchIntegratedServer(CallbackInfo ci) {
-		EventLaunchIntegratedServer.fireOnLaunchIntegratedServer();
-	}
-	
-	@Inject(method = "Lnet/minecraft/client/Minecraft;loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/PlayerControllerMP;flipPlayer(Lnet/minecraft/entity/player/EntityPlayer;)V"))
-	public void inject_loadWorld(CallbackInfo ci) {
-		EventDoneLoadingWorld.fireOnDoneLoadingWorld();
-	}
-	
-	@Shadow
-	private GuiScreen currentScreen;
-	
-	@Redirect(method = "displayGuiScreen", at = @At(value = "FIELD", target = "Lnet/minecraft/client/Minecraft;currentScreen:Lnet/minecraft/client/gui/GuiScreen;", opcode = Opcodes.PUTFIELD))
-	public void modify_displayGuiScreen(Minecraft mc, GuiScreen guiScreen) {
-		guiScreen = EventOpenGui.fireOpenGuiEvent(guiScreen);
-		currentScreen = guiScreen;
-	}
+
+    @Inject(method = "init", at = @At(value = "RETURN"))
+    public void inject_init(CallbackInfo ci) {
+        EventListenerRegistry.fireEvent(EventClientInit.class, (Minecraft) (Object) this);
+    }
+
+    @Inject(method = "runGameLoop", at = @At(value = "HEAD"))
+    public void inject_runGameLoop(CallbackInfo ci) {
+        EventListenerRegistry.fireEvent(EventClientGameLoop.class, (Minecraft) (Object) this);
+    }
+
+    @Inject(method = "runTick", at = @At("HEAD"))
+    public void inject_runTick(CallbackInfo ci) {
+        EventListenerRegistry.fireEvent(EventClientTick.class, (Minecraft) (Object) this);
+    }
+
+    @Inject(method = "launchIntegratedServer", at = @At("HEAD"))
+    public void inject_launchIntegratedServer(CallbackInfo ci) {
+        EventListenerRegistry.fireEvent(EventLaunchIntegratedServer.class);
+    }
+
+    @Inject(method = "Lnet/minecraft/client/Minecraft;loadWorld(Lnet/minecraft/client/multiplayer/WorldClient;Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/PlayerControllerMP;flipPlayer(Lnet/minecraft/entity/player/EntityPlayer;)V"))
+    public void inject_loadWorld(CallbackInfo ci) {
+        EventListenerRegistry.fireEvent(EventDoneLoadingWorld.class);
+    }
+
+    @Shadow
+    private GuiScreen currentScreen;
+
+    @Redirect(method = "displayGuiScreen", at = @At(value = "FIELD", target = "Lnet/minecraft/client/Minecraft;currentScreen:Lnet/minecraft/client/gui/GuiScreen;", opcode = Opcodes.PUTFIELD))
+    public void modify_displayGuiScreen(Minecraft mc, GuiScreen guiScreen) {
+        guiScreen = (GuiScreen) EventListenerRegistry.fireEvent(EventOpenGui.class, guiScreen);
+        currentScreen = guiScreen;
+    }
 }

--- a/src/main/java/com/minecrafttas/mctcommon/mixin/MixinMinecraftServer.java
+++ b/src/main/java/com/minecrafttas/mctcommon/mixin/MixinMinecraftServer.java
@@ -1,5 +1,6 @@
 package com.minecrafttas.mctcommon.mixin;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.At.Shift;
@@ -18,21 +19,21 @@ public class MixinMinecraftServer {
 	
 	@Inject(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;init()Z", shift = Shift.AFTER))
 	public void inject_init(CallbackInfo ci) {
-		EventServerInit.fireServerStartEvent((MinecraftServer)(Object)this);
+		EventListenerRegistry.fireEvent(EventServerInit.class, (MinecraftServer)(Object)this);
 	}
 	
 	@Inject(method = "initiateShutdown", at = @At("HEAD"))
 	public void inject_initiateShutDown(CallbackInfo ci) {
-		EventServerStop.fireOnServerStop((MinecraftServer)(Object)this);
+		EventListenerRegistry.fireEvent(EventServerStop.class, (MinecraftServer)(Object)this);
 	}
 	
 	@Inject(method = "tick", at = @At("HEAD"))
 	public void inject_tick(CallbackInfo ci) {
-		EventServerTick.fireOnServerTick((MinecraftServer)(Object)this);
+		EventListenerRegistry.fireEvent(EventServerTick.class, (MinecraftServer)(Object)this);
 	}
 	
 //	@Inject(method = "run", at = @At(value = "FIELD", target = "Lnet/minecraft/server/MinecraftServer;serverRunning:Z", shift = Shift.AFTER))
 	public void inject_run(CallbackInfo ci) {
-		EventServerGameLoop.fireOnServerGameLoop((MinecraftServer)(Object)this);
+		EventListenerRegistry.fireEvent(EventServerGameLoop.class, (MinecraftServer)(Object)this);
 	}
 }

--- a/src/main/java/com/minecrafttas/mctcommon/mixin/MixinNetHandlerPlayClient.java
+++ b/src/main/java/com/minecrafttas/mctcommon/mixin/MixinNetHandlerPlayClient.java
@@ -2,6 +2,7 @@ package com.minecrafttas.mctcommon.mixin;
 
 import java.net.ConnectException;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -23,14 +24,14 @@ public class MixinNetHandlerPlayClient {
 
 	@Inject(method = "handleJoinGame", at = @At(value = "RETURN"))
 	public void clientJoinServerEvent(CallbackInfo ci) throws ConnectException {
-		EventPlayerJoinedClientSide.firePlayerJoinedClientSide(gameController.player);
+		EventListenerRegistry.fireEvent(EventPlayerJoinedClientSide.class, gameController.player);
 	}
 
 	@Inject(method = "handlePlayerListItem", at = @At(value = "HEAD"))
 	public void otherClientJoinServerEvent(SPacketPlayerListItem packet, CallbackInfo ci) {
 		for (int i = 0; i < packet.getEntries().size(); i++) {
 			if (packet.getAction() == Action.ADD_PLAYER) {
-				EventOtherPlayerJoinedClientSide.fireOtherPlayerJoinedClientSide(packet.getEntries().get(i).getProfile());
+				EventListenerRegistry.fireEvent(EventOtherPlayerJoinedClientSide.class, packet.getEntries().get(i).getProfile());
 			}
 		}
 	}

--- a/src/main/java/com/minecrafttas/mctcommon/mixin/MixinPlayerList.java
+++ b/src/main/java/com/minecrafttas/mctcommon/mixin/MixinPlayerList.java
@@ -1,5 +1,6 @@
 package com.minecrafttas.mctcommon.mixin;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,13 +15,13 @@ import net.minecraft.server.management.PlayerList;
 
 @Mixin(PlayerList.class)
 public class MixinPlayerList {
-	@Inject(method="initializeConnectionToPlayer", at=@At("RETURN"), remap = false)
-	public void inject_initializeConnectionToPlayer(NetworkManager netManager, EntityPlayerMP playerIn, CallbackInfo ci){
-		EventPlayerJoinedServerSide.firePlayerJoinedServerSide(playerIn);
-	}
-	
-	@Inject(method = "playerLoggedOut", at = @At("HEAD"))
-	public void inject_playerLoggedOut(EntityPlayerMP playerIn, CallbackInfo ci) {
-		EventPlayerLeaveServerSide.firePlayerLeaveServerSide(playerIn);
-	}
+    @Inject(method = "initializeConnectionToPlayer", at = @At("RETURN"), remap = false)
+    public void inject_initializeConnectionToPlayer(NetworkManager netManager, EntityPlayerMP playerIn, CallbackInfo ci) {
+        EventListenerRegistry.fireEvent(EventPlayerJoinedServerSide.class, playerIn);
+    }
+
+    @Inject(method = "playerLoggedOut", at = @At("HEAD"))
+    public void inject_playerLoggedOut(EntityPlayerMP playerIn, CallbackInfo ci) {
+        EventListenerRegistry.fireEvent(EventPlayerLeaveServerSide.class, playerIn);
+    }
 }

--- a/src/main/java/com/minecrafttas/mctcommon/mixin/MixinWorldClient.java
+++ b/src/main/java/com/minecrafttas/mctcommon/mixin/MixinWorldClient.java
@@ -1,5 +1,6 @@
 package com.minecrafttas.mctcommon.mixin;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,6 +15,6 @@ import net.minecraft.client.multiplayer.WorldClient;
 public class MixinWorldClient {
 	@Inject(method = "sendQuittingDisconnectingPacket", at = @At(value = "HEAD"))
 	public void clientLeaveServerEvent(CallbackInfo ci) {
-		EventPlayerLeaveClientSide.firePlayerLeaveClientSide(Minecraft.getMinecraft().player);
+		EventListenerRegistry.fireEvent(EventPlayerLeaveClientSide.class, Minecraft.getMinecraft().player);
 	}
 }

--- a/src/main/java/com/minecrafttas/mctcommon/server/Client.java
+++ b/src/main/java/com/minecrafttas/mctcommon/server/Client.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Marker;
 
 import com.minecrafttas.mctcommon.MCTCommon;
 import com.minecrafttas.mctcommon.events.EventClient.EventDisconnectClient;
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import com.minecrafttas.mctcommon.events.EventServer.EventClientCompleteAuthentication;
 import com.minecrafttas.mctcommon.server.exception.InvalidPacketException;
 import com.minecrafttas.mctcommon.server.exception.PacketNotImplementedException;
@@ -83,7 +84,11 @@ public class Client {
 		this.createHandlers();
 
 		this.callback = (client) -> {
-			EventDisconnectClient.fireDisconnectClient(client);
+			try {
+				EventListenerRegistry.fireEvent(EventDisconnectClient.class, client);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
 		};
 
 		this.local = local;

--- a/src/main/java/com/minecrafttas/mctcommon/server/Client.java
+++ b/src/main/java/com/minecrafttas/mctcommon/server/Client.java
@@ -84,11 +84,7 @@ public class Client {
 		this.createHandlers();
 
 		this.callback = (client) -> {
-			try {
-				EventListenerRegistry.fireEvent(EventDisconnectClient.class, client);
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
+			EventListenerRegistry.fireEvent(EventDisconnectClient.class, client);
 		};
 
 		this.local = local;

--- a/src/main/java/com/minecrafttas/mctcommon/server/Client.java
+++ b/src/main/java/com/minecrafttas/mctcommon/server/Client.java
@@ -219,10 +219,9 @@ public class Client {
 	}
 
 	/**
-	 * Write packet to server
+	 * Sends a packet to the server
 	 * 
-	 * @param id  Buffer id
-	 * @param buf Buffer
+	 * @param bufferBuilder The bufferbuilder to use for sending a packet
 	 * @throws Exception Networking exception
 	 */
 	public void send(ByteBufferBuilder bufferBuilder) throws Exception {
@@ -293,7 +292,7 @@ public class Client {
 
 		this.username = ByteBufferBuilder.readString(buf);
 		LOGGER.debug(getLoggerMarker(), "Completing authentication for user {}", username);
-		EventClientCompleteAuthentication.fireClientCompleteAuthentication(username);
+		EventListenerRegistry.fireEvent(EventClientCompleteAuthentication.class, username);
 	}
 
 	private void handle(ByteBuffer buf) {
@@ -327,7 +326,7 @@ public class Client {
 				return packet;
 			}
 		}
-		throw new InvalidPacketException(String.format("Received invalid packet with id {}", id));
+		throw new InvalidPacketException(String.format("Received invalid packet with id %s", id));
 	}
 
 	public boolean isClosed() {

--- a/src/main/java/com/minecrafttas/mctcommon/server/CompactPacketHandler.java
+++ b/src/main/java/com/minecrafttas/mctcommon/server/CompactPacketHandler.java
@@ -1,4 +1,4 @@
-package com.minecrafttas.mctcommon.events;
+package com.minecrafttas.mctcommon.server;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/com/minecrafttas/mctcommon/server/Server.java
+++ b/src/main/java/com/minecrafttas/mctcommon/server/Server.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.minecrafttas.mctcommon.MCTCommon;
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import com.minecrafttas.mctcommon.events.EventServer.EventDisconnectServer;
 import com.minecrafttas.mctcommon.server.Client.ClientCallback;
 import com.minecrafttas.mctcommon.server.interfaces.PacketID;
@@ -49,7 +50,7 @@ public class Server {
 			public void completed(AsynchronousSocketChannel clientSocket, Object attachment) {
 				
 				ClientCallback callback = (client) -> {
-					EventDisconnectServer.fireDisconnectServer(client);
+					EventListenerRegistry.fireEvent(EventDisconnectServer.class, client);
 					clients.remove(client);
 					LOGGER.debug(Server, "Disconnecting player from server");
 				};

--- a/src/main/java/com/minecrafttas/mctcommon/server/interfaces/PacketID.java
+++ b/src/main/java/com/minecrafttas/mctcommon/server/interfaces/PacketID.java
@@ -1,6 +1,6 @@
 package com.minecrafttas.mctcommon.server.interfaces;
 
-import com.minecrafttas.mctcommon.events.CompactPacketHandler;
+import com.minecrafttas.mctcommon.server.CompactPacketHandler;
 import com.minecrafttas.mctcommon.server.Client.Side;
 
 public interface PacketID {

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -23,7 +23,6 @@ import com.minecrafttas.mctcommon.server.Client;
 import com.minecrafttas.mctcommon.server.PacketHandlerRegistry;
 import com.minecrafttas.mctcommon.server.Server;
 import com.minecrafttas.tasmod.gui.InfoHud;
-import com.minecrafttas.tasmod.handlers.InterpolationHandler;
 import com.minecrafttas.tasmod.handlers.LoadingScreenHandler;
 import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
 import com.minecrafttas.tasmod.networking.TASmodPackets;
@@ -82,8 +81,6 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 	public static LoadingScreenHandler loadingScreenHandler;
 	
 	public static KeybindManager keybindManager;
-	
-	public static InterpolationHandler interpolation = new InterpolationHandler();
 	
 	public static SavestateHandlerClient savestateHandlerClient = new SavestateHandlerClient();
 	
@@ -150,7 +147,6 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		EventListenerRegistry.register(loadingScreenHandler);
 		EventListenerRegistry.register(ticksyncClient);
 		EventListenerRegistry.register(keybindManager);
-//		EventListenerRegistry.register(interpolation);
 		EventListenerRegistry.register((EventOpenGui)(gui -> {
 			if(gui instanceof GuiMainMenu) {
 				openMainMenuScheduler.runAllTasks();
@@ -312,5 +308,4 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		}
 		return gui;
 	}
-	
 }

--- a/src/main/java/com/minecrafttas/tasmod/events/EventClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/EventClient.java
@@ -1,74 +1,47 @@
 package com.minecrafttas.tasmod.events;
 
-import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
-
 import net.minecraft.client.Minecraft;
 
+/**
+ * TASmod specific events fired on the client side
+ *
+ * @author Scribble
+ */
 public interface EventClient {
 	
 	/**
 	 * Fired when the hotbar is drawn on screen
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventDrawHotbar extends EventBase{
 		/**
 		 * Fired when the hotbar is drawn on screen
 		 */
 		public void onDrawHotbar();
-		
-		public static void fireOnDrawHotbar() {
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventDrawHotbar) {
-					EventDrawHotbar event = (EventDrawHotbar) eventListener;
-					event.onDrawHotbar();
-				}
-			}
-		}
 	}
 	
 	/**
 	 * Fired at the end of a client tick
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventClientTickPost extends EventBase{
 		
 		/**
 		 * Fired at the end of a client tick
 		 */
 		public void onClientTickPost(Minecraft mc);
-		
-		public static void fireOnClientPostTick(Minecraft mc) {
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventClientTickPost) {
-					EventClientTickPost event = (EventClientTickPost) eventListener;
-					event.onClientTickPost(mc);
-				}
-			}
-		}
 	}
 	
 	/**
 	 * Fired when the tickrate changes on the client side
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventClientTickrateChange extends EventBase{
 		
 		/**
 		 * Fired at the end of a client tick
 		 */
 		public void onClientTickrateChange(float tickrate);
-		
-		public static void fireOnClientTickrateChange(float tickrate) {
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventClientTickrateChange) {
-					EventClientTickrateChange event = (EventClientTickrateChange) eventListener;
-					event.onClientTickrateChange(tickrate);
-				}
-			}
-		}
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/events/EventServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/EventServer.java
@@ -1,22 +1,21 @@
 package com.minecrafttas.tasmod.events;
 
-import static com.minecrafttas.tasmod.TASmod.LOGGER;
+import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
+import net.minecraft.server.MinecraftServer;
 
 import java.io.File;
 
-import com.minecrafttas.mctcommon.events.EventListenerRegistry;
-import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
-import com.minecrafttas.tasmod.util.LoggerMarkers;
-
-import net.minecraft.server.MinecraftServer;
-
+/**
+ * TASmod specific events fired on the server side
+ *
+ * @author Scribble
+ */
 public interface EventServer {
 	
 	/**
 	 * Fired when saving a savestate, before the savestate folder is copied
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventSavestate extends EventBase {
 		
 		/**
@@ -26,23 +25,12 @@ public interface EventServer {
 		 * @param current The current folder that will be copied from
 		 */
 		public void onSavestateEvent(int index, File target, File current);
-		
-		public static void fireSavestateEvent(int index, File target, File current) {
-			LOGGER.trace(LoggerMarkers.Event, "SavestateEvent {} {} {}", index, target, current);
-			for (EventBase eventListener : TASmodEventListener.getEventListeners()) {
-				if(eventListener instanceof EventSavestate) {
-					EventSavestate event = (EventSavestate) eventListener;
-					event.onSavestateEvent(index, target, current);
-				}
-			}
-		}
 	}
 	
 	/**
 	 * Fired when loading a savestate, before the savestate folder is copied
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventLoadstate extends EventBase {
 		
 		/**
@@ -52,85 +40,43 @@ public interface EventServer {
 		 * @param current The current folder that will be copied from
 		 */
 		public void onLoadstateEvent(int index, File target, File current);
-		
-		public static void fireLoadstateEvent(int index, File target, File current) {
-			LOGGER.trace(LoggerMarkers.Event, "LoadstateEvent {} {} {}", index, target, current);
-			for (EventBase eventListener : TASmodEventListener.getEventListeners()) {
-				if(eventListener instanceof EventLoadstate) {
-					EventLoadstate event = (EventLoadstate) eventListener;
-					event.onLoadstateEvent(index, target, current);
-				}
-			}
-		}
 	}
 
 	
 	/**
 	 * Fired one tick after a loadstate was carried out
-	 * @author Scribble
-	 * 
 	 */
+	@FunctionalInterface
 	public static interface EventCompleteLoadstate extends EventBase{
 		
 		/**
 		 * Fired one tick after a loadstate was carried out
 		 */
 		public void onLoadstateComplete();
-		
-		public static void fireLoadstateComplete() {
-			LOGGER.trace(LoggerMarkers.Event, "LoadstateCompleteEvent");
-			for (EventBase eventListener : TASmodEventListener.getEventListeners()) {
-				if(eventListener instanceof EventCompleteLoadstate) {
-					EventCompleteLoadstate event = (EventCompleteLoadstate) eventListener;
-					event.onLoadstateComplete();
-				}
-			}
-		}
 	}
 	
 	/**
 	 * Fired at the end of a server tick
-	 * @author Scribble
-	 * 
 	 */
+	@FunctionalInterface
 	public static interface EventServerTickPost extends EventBase{
 		
 		/**
 		 * Fired at the end of a server tick
 		 */
 		public void onServerTickPost(MinecraftServer minecraftServer);
-		
-		public static void fireServerTickPost(MinecraftServer minecraftServer) {
-//			LOGGER.trace(LoggerMarkers.Event, "ServerTickPostEvent");
-			for (EventBase eventListener : TASmodEventListener.getEventListeners()) {
-				if(eventListener instanceof EventServerTickPost) {
-					EventServerTickPost event = (EventServerTickPost) eventListener;
-					event.onServerTickPost(minecraftServer);
-				}
-			}
-		}
 	}
 
 	
 	/**
 	 * Fired when the tickrate changes on the server side
-	 * @author Scribble
-	 *
 	 */
+	@FunctionalInterface
 	public static interface EventServerTickrateChange extends EventBase{
 		
 		/**
 		 * Fired at the end of a client tick
 		 */
 		public void onServerTickrateChange(float tickrate);
-		
-		public static void fireOnServerTickrateChange(float tickrate) {
-			for (EventBase eventListener : EventListenerRegistry.getEventListeners()) {
-				if(eventListener instanceof EventServerTickrateChange) {
-					EventServerTickrateChange event = (EventServerTickrateChange) eventListener;
-					event.onServerTickrateChange(tickrate);
-				}
-			}
-		}
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraft.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraft.java
@@ -2,6 +2,7 @@ package com.minecrafttas.tasmod.mixin;
 
 import java.io.IOException;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -57,7 +58,7 @@ public abstract class MixinMinecraft {
 			TASmodClient.tickratechanger.advanceTick = false;
 			TASmodClient.tickratechanger.changeClientTickrate(0F);
 		}
-		EventClientTickPost.fireOnClientPostTick((Minecraft)(Object)this);
+		EventListenerRegistry.fireEvent(EventClientTickPost.class, (Minecraft)(Object)this);
 	}
 
 	@Shadow

--- a/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraftServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraftServer.java
@@ -3,6 +3,7 @@ package com.minecrafttas.tasmod.mixin;
 import java.util.Queue;
 import java.util.concurrent.FutureTask;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -76,7 +77,7 @@ public abstract class MixinMinecraftServer {
 				TASmod.tickratechanger.changeServerTickrate(0F);
 				TASmod.tickratechanger.advanceTick = false;
 			}
-			EventServerTickPost.fireServerTickPost((MinecraftServer)(Object)this);
+			EventListenerRegistry.fireEvent(EventServerTickPost.class, (MinecraftServer)(Object)this);
 			
 			long tickDuration = System.currentTimeMillis() - timeBeforeTick;
 			

--- a/src/main/java/com/minecrafttas/tasmod/mixin/events/MixinGuiIngame.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/events/MixinGuiIngame.java
@@ -1,5 +1,6 @@
 package com.minecrafttas.tasmod.mixin.events;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,6 +15,6 @@ public class MixinGuiIngame {
 	
 	@Inject(method = "renderHotbar", at = @At("HEAD"))
 	public void inject_renderHotbar(CallbackInfo ci) {
-		EventDrawHotbar.fireOnDrawHotbar();
+		EventListenerRegistry.fireEvent(EventDrawHotbar.class);
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/networking/TASmodPackets.java
+++ b/src/main/java/com/minecrafttas/tasmod/networking/TASmodPackets.java
@@ -1,6 +1,6 @@
 package com.minecrafttas.tasmod.networking;
 
-import com.minecrafttas.mctcommon.events.CompactPacketHandler;
+import com.minecrafttas.mctcommon.server.CompactPacketHandler;
 import com.minecrafttas.mctcommon.server.Client.Side;
 import com.minecrafttas.mctcommon.server.interfaces.PacketID;
 import com.minecrafttas.tasmod.commands.CommandFolder;

--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
 
@@ -196,7 +197,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		File currentfolder = new File(savestateDirectory, ".." + File.separator + worldname);
 		File targetfolder = getSavestateFile(indexToSave);
 		
-		EventSavestate.fireSavestateEvent(indexToSave, targetfolder, currentfolder);
+		EventListenerRegistry.fireEvent(EventSavestate.class, indexToSave, targetfolder, currentfolder);
 
 		if (targetfolder.exists()) {
 			logger.warn(LoggerMarkers.Savestate, "WARNING! Overwriting the savestate with the index {}", indexToSave);
@@ -339,7 +340,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		File currentfolder = new File(savestateDirectory, ".." + File.separator + worldname);
 		File targetfolder = getSavestateFile(indexToLoad);
 
-		EventLoadstate.fireLoadstateEvent(indexToLoad, targetfolder, currentfolder);
+		EventListenerRegistry.fireEvent(EventLoadstate.class, indexToLoad, targetfolder, currentfolder);
 		
 		/*
 		 * Prevents loading an InputSavestate when loading index 0 (Index 0 is the
@@ -418,7 +419,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 
 		
 		TASmod.tickSchedulerServer.add(()->{
-			EventCompleteLoadstate.fireLoadstateComplete();
+			EventListenerRegistry.fireEvent(EventCompleteLoadstate.class);
 			onLoadstateComplete();
 			
 			// Unlock savestating
@@ -922,7 +923,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		}
 
 		/**
-		 * Loads all worlds and players from the disk. Also sends the playerdata to the client in {@linkplain SavestatePlayerLoadingPacketHandler}
+		 * Loads all worlds and players from the disk. Also sends the playerdata to the client in {@linkplain SavestateHandlerClient#onClientPacket(PacketID, ByteBuffer, String)}
 		 * 
 		 * Side: Server
 		 */
@@ -1065,7 +1066,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		 * This adds the player to the chunk map so the server knows it can send the information to the client<br>
 		 * <br>
 		 * Side: Server
-		 * @see disconnectPlayersFromChunkMap
+		 * @see #disconnectPlayersFromChunkMap(MinecraftServer)
 		 */
 		public static void addPlayersToChunkMap(MinecraftServer server) {
 			List<EntityPlayerMP> players=server.getPlayerList().getPlayers();
@@ -1094,7 +1095,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		 * Removing the player stops the server from sending chunks to the client.<br>
 		 * <br>
 		 * Side: Server
-		 * @see SavestatesChunkControl#addPlayersToChunkMap()
+		 * @see #addPlayersToChunkMap(MinecraftServer)
 		 */
 		public static void disconnectPlayersFromChunkMap(MinecraftServer server) {
 			List<EntityPlayerMP> players=server.getPlayerList().getPlayers();

--- a/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerClient.java
@@ -4,6 +4,7 @@ import static com.minecrafttas.tasmod.TASmod.LOGGER;
 
 import java.nio.ByteBuffer;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import com.minecrafttas.mctcommon.server.Client.Side;
 import com.minecrafttas.mctcommon.server.exception.PacketNotImplementedException;
 import com.minecrafttas.mctcommon.server.exception.WrongSideException;
@@ -88,16 +89,16 @@ public class TickrateChangerClient implements ClientPacketHandler {
 			mc.timer.tickLength = Float.MAX_VALUE;
 		}
 		ticksPerSecond = tickrate;
-		EventClientTickrateChange.fireOnClientTickrateChange(tickrate);
+		EventListenerRegistry.fireEvent(EventClientTickrateChange.class, tickrate);
 		if (log)
 			log("Setting the client tickrate to " + ticksPerSecond);
 	}
 
 	/**
 	 * Attempts to change the tickrate on the server. Sends a
-	 * {@link ChangeTickratePacket} to the server
+	 * {@link TASmodPackets#TICKRATE_CHANGE} packet to the server
 	 * 
-	 * @param tickrate
+	 * @param tickrate The new server tickrate
 	 */
 	public void changeServerTickrate(float tickrate) {
 		if (tickrate < 0) {

--- a/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerServer.java
@@ -2,6 +2,7 @@ package com.minecrafttas.tasmod.tickratechanger;
 
 import java.nio.ByteBuffer;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import org.apache.logging.log4j.Logger;
 
 import com.minecrafttas.mctcommon.events.EventServer.EventPlayerJoinedServerSide;
@@ -87,7 +88,7 @@ public class TickrateChangerServer implements EventServerStop, EventPlayerJoined
 	}
 
 	/**
-	 * Changes the tickrate of all clients. Sends a {@link ChangeTickratePacket}
+	 * Changes the tickrate of all clients. Sends a {@link TASmodPackets#TICKRATE_CHANGE} packet to all clients
 	 * 
 	 * @param tickrate The new tickrate of the client
 	 * @param log      If a message should logged
@@ -127,7 +128,7 @@ public class TickrateChangerServer implements EventServerStop, EventPlayerJoined
 			}
 		}
 		ticksPerSecond = tickrate;
-		EventServerTickrateChange.fireOnServerTickrateChange(tickrate);
+		EventListenerRegistry.fireEvent(EventServerTickrateChange.class, tickrate);
 		if (log) {
 			log("Setting the server tickrate to " + ticksPerSecond);
 		}
@@ -180,7 +181,7 @@ public class TickrateChangerServer implements EventServerStop, EventPlayerJoined
 	}
 
 	/**
-	 * Sends a {@link AdvanceTickratePacket} to all clients
+	 * Sends a {@link TASmodPackets#TICKRATE_ADVANCE} packet to all clients
 	 */
 	private void advanceClientTick() {
 		// Do not check for ticksPerSecond==0 here, because at this point, ticksPerSecond is 20 for one tick!

--- a/src/test/java/mctcommon/event/EventTest.java
+++ b/src/test/java/mctcommon/event/EventTest.java
@@ -1,38 +1,172 @@
 package mctcommon.event;
 
+import com.minecrafttas.mctcommon.events.EventException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class EventTest {
 
-	@FunctionalInterface
-	private interface TestEvent extends EventBase{
-		
-		public void onTestEvent();
-		
-		public static void test() {};
-	}
-	
-	@Test
-	void testRegisteringEvents() {
-		
-		
-		TestEvent event = new TestEvent() {
-			@Override
-			public void onTestEvent() {
-				System.out.println("Test");
-			}
-		};
-		
-		EventListenerRegistry.register(event);
-		
-		try {
-			EventListenerRegistry.fireEvent(TestEvent.class);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
+    @FunctionalInterface
+    private interface TestEvent extends EventBase {
 
+        public int onTestEvent();
+
+    }
+
+    @FunctionalInterface
+    private interface AdditionEvent extends EventBase {
+
+        public int onAdditionEvent(int left, int right);
+
+    }
+
+    @AfterEach
+    void afterEach() {
+        EventListenerRegistry.clear();
+    }
+
+    /**
+     * Registers an event which returns 5
+     */
+    @Test
+    void testSimpleEvent() {
+        TestEvent event = () -> 5;
+
+        EventListenerRegistry.register(event);
+
+        int actual = (int) EventListenerRegistry.fireEvent(TestEvent.class);
+        assertEquals(5, actual);
+    }
+
+    /**
+     * Test event with parameters
+     */
+    @Test
+    void testParameterEvent() {
+        AdditionEvent event = Integer::sum;
+
+        EventListenerRegistry.register(event);
+
+        int actual = (int) EventListenerRegistry.fireEvent(AdditionEvent.class, 3, 6);
+
+        assertEquals(9, actual);
+    }
+
+    /**
+     * Test event with parameters, but too few parameters are fired
+     */
+    @Test
+    void testParameterEventTooFew() {
+        AdditionEvent event = Integer::sum;
+
+        EventListenerRegistry.register(event);
+
+        Exception exception = assertThrows(EventException.class, () -> {
+            EventListenerRegistry.fireEvent(AdditionEvent.class, 3);
+        });
+
+        String expected = "mctcommon.event.EventTest$AdditionEvent: Event fired with the wrong number of parameters. Expected: 2, Actual: 1";
+        assertEquals(expected, exception.getMessage());
+    }
+
+    /**
+     * Test event with parameters, but too many parameters are fired
+     */
+    @Test
+    void testParameterEventTooMany() {
+        AdditionEvent event = new AdditionEvent() {
+            @Override
+            public int onAdditionEvent(int left, int right) {
+                return left + right;
+            }
+        };
+
+        EventListenerRegistry.register(event);
+
+        Exception exception = assertThrows(EventException.class, () -> {
+            EventListenerRegistry.fireEvent(AdditionEvent.class, 3, 1, 3);
+        });
+
+        String expected = "mctcommon.event.EventTest$AdditionEvent: Event fired with the wrong number of parameters. Expected: 2, Actual: 3";
+        assertEquals(expected, exception.getMessage());
+    }
+
+    /**
+     * Test multiple return values
+     */
+    @Test
+    void testMultipleReturnValues() {
+        TestEvent event = () -> 5;
+        TestEvent event2 = () -> 7;
+
+        EventListenerRegistry.register(event);
+        EventListenerRegistry.register(event2);
+
+        int actual = (int) EventListenerRegistry.fireEvent(TestEvent.class);
+        assertEquals(7, actual);
+    }
+
+    /**
+     * Tests a class which has an additional method with the same name but different parameters
+     */
+    @Test
+    void testEventMethodwithSameName() {
+
+        class TestClass implements TestEvent {
+
+            public int onTestEvent(int test) {
+                return test;
+            }
+
+            @Override
+            public int onTestEvent() {
+                return 1;
+            }
+        }
+
+        TestClass test = new TestClass();
+
+        EventListenerRegistry.register(test);
+
+        int actual = (int) EventListenerRegistry.fireEvent(TestEvent.class);
+
+        assertEquals(1, actual);
+    }
+
+    /**
+     * Test mismatched types
+     */
+    @Test
+    void testParameterEventWrongTypes() {
+        AdditionEvent event = Integer::sum;
+
+        EventListenerRegistry.register(event);
+
+        Exception exception = assertThrows(EventException.class, () -> EventListenerRegistry.fireEvent(AdditionEvent.class, 3, 6D));
+
+        String expected = "mctcommon.event.EventTest$AdditionEvent: Event seems to be fired with the wrong parameter types or in the wrong order";
+        assertEquals(expected, exception.getMessage());
+    }
+
+    /**
+     * Test unregistering eventlistener
+     */
+    @Test
+    void testUnregister() {
+        TestEvent event = () -> 5;
+
+        EventListenerRegistry.register(event);
+
+        EventListenerRegistry.unregister(event);
+
+        Exception exception = assertThrows(EventException.class, () -> EventListenerRegistry.fireEvent(TestEvent.class));
+
+        String expected = "mctcommon.event.EventTest$TestEvent: The event has not been registered yet";
+        assertEquals(expected, exception.getMessage());
+    }
 }

--- a/src/test/java/mctcommon/event/EventTest.java
+++ b/src/test/java/mctcommon/event/EventTest.java
@@ -1,0 +1,38 @@
+package mctcommon.event;
+
+import org.junit.jupiter.api.Test;
+
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
+import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
+
+public class EventTest {
+
+	@FunctionalInterface
+	private interface TestEvent extends EventBase{
+		
+		public void onTestEvent();
+		
+		public static void test() {};
+	}
+	
+	@Test
+	void testRegisteringEvents() {
+		
+		
+		TestEvent event = new TestEvent() {
+			@Override
+			public void onTestEvent() {
+				System.out.println("Test");
+			}
+		};
+		
+		EventListenerRegistry.register(event);
+		
+		try {
+			EventListenerRegistry.fireEvent(TestEvent.class);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/src/test/java/mctcommon/server/ByteBufferBuilderTest.java
+++ b/src/test/java/mctcommon/server/ByteBufferBuilderTest.java
@@ -10,8 +10,8 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
-import com.minecrafttas.mctcommon.events.CompactPacketHandler;
 import com.minecrafttas.mctcommon.server.ByteBufferBuilder;
+import com.minecrafttas.mctcommon.server.CompactPacketHandler;
 import com.minecrafttas.mctcommon.server.Client.Side;
 import com.minecrafttas.mctcommon.server.interfaces.PacketID;
 

--- a/src/test/java/mctcommon/server/ServerTest.java
+++ b/src/test/java/mctcommon/server/ServerTest.java
@@ -15,9 +15,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.minecrafttas.mctcommon.events.CompactPacketHandler;
 import com.minecrafttas.mctcommon.server.ByteBufferBuilder;
 import com.minecrafttas.mctcommon.server.Client;
+import com.minecrafttas.mctcommon.server.CompactPacketHandler;
 import com.minecrafttas.mctcommon.server.Client.Side;
 import com.minecrafttas.mctcommon.server.PacketHandlerRegistry;
 import com.minecrafttas.mctcommon.server.Server;

--- a/src/test/java/tasmod/networking/TASmodByteBufferBuilderTest.java
+++ b/src/test/java/tasmod/networking/TASmodByteBufferBuilderTest.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
-import com.minecrafttas.mctcommon.events.CompactPacketHandler;
+import com.minecrafttas.mctcommon.server.CompactPacketHandler;
 import com.minecrafttas.mctcommon.server.Client.Side;
 import com.minecrafttas.mctcommon.server.interfaces.PacketID;
 import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;


### PR DESCRIPTION
Improved event handling in preparation of #193
Continuation of my refactor attempt in c5782562f6e2fe739f58f92ac1e57237fad0e906 , which I postponed at the time

## Changes
### Firing events
Added a single `fireEvent()` method that takes the class of the event to fire as a parameter  
and removed the `fire` methods in each individual event.

### Registering event listeners
Instead of the registry just being one big list with all event listeners, the registry is now a hasmap of arraylists.  
This is to avoid iterating over the entire list, to find which event listeners listens for the event that is being fired.

By using the Event.class as a key during registering, EVENTLISTENER_REGISTRY.get() returns the list of listeners that do actually implement the event.

### Registering lambdas
Coincidentally, it is now possible to register lambdas as event listeners.

### Misc
Moved CompactPacketHandler to `server` package as that it where it actually belongs