### PR TITLE
Refactor PlaybackController

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2.4.0
       with:
-        gradle-version: 8.4
+        gradle-version: 8.6
     - name: Build TASmod with Gradle
       run: gradle build
     - name: Upload Test Report

--- a/.github/workflows/buildandupload.yml
+++ b/.github/workflows/buildandupload.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2.4.0
       with:
-        gradle-version: 8.4
+        gradle-version: 8.6
     - name: Build TASmod with Gradle
       run: gradle build
     - name: Upload artifact

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx3G
 
 # Fabric properties
 minecraft_version=1.12.2
-loader_version=0.15.6
-loom_version=1.5-SNAPSHOT
+loader_version=0.15.9
+loom_version=1.6-SNAPSHOT
 
 # Mod properties
 mod_name=Tool-Assisted Speedrun Mod

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
@@ -107,6 +107,10 @@ public class EventListenerRegistry {
         }
     }
     
+    /**
+     * Registers multiple objects to be an event listener. The objects must implement an event extending {@link EventBase}
+     * @param eventListeners The event listeners to register
+     */
     public static void register(EventBase... eventListeners) {
     	for(EventBase eventListener : eventListeners) {
     		register(eventListener);
@@ -128,13 +132,23 @@ public class EventListenerRegistry {
 				if (registryList != null) {
 					registryList.remove(eventListener);
 
-					if (registryList.isEmpty()) {
-						EVENTLISTENER_REGISTRY.remove(type);
-					}
-				}
-			}
-		}
-	}
+                    if (registryList.isEmpty()) {
+                        EVENTLISTENER_REGISTRY.remove(type);
+                    }
+                }
+            }
+        }
+    }
+    
+    /**
+     * Unregisters multiple objects from being an event listener.
+     * @param eventListener The event listeners to unregister
+     */
+    public static void unregister(EventBase... eventListeners) {
+    	for(EventBase eventListener : eventListeners) {
+    		unregister(eventListener);
+    	}
+    }
 
 	/**
 	 * Fires an event without parameters

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
@@ -12,90 +12,78 @@ import java.util.HashMap;
  * <br>
  * Implement an EventInterface into your class, then implement the function.<br>
  * <br>
- * In your initializer method, register the instance of the class with
- * {@link EventListenerRegistry#register(EventBase)} <br>
+ * In your initializer method, register the instance of the class with {@link EventListenerRegistry#register(EventBase)}
+ * <br>
  * Example:
- * 
  * <pre>
- * public class ClassWithListener implements EventInit {
+ *     public class ClassWithListener implements EventInit {
  *
- * 	&#64;Override
- * 	public void onEventInit() {
- * 		// Implement event specific code
- * 	}
- * }
+ *          @ Override
+ *          public void onEventInit() {
+ *              // Implement event specific code
+ *          }
+ *     }
  * </pre>
- * 
  * <br>
  * To create and fire your own events, check {@link EventBase}<br>
  */
 public class EventListenerRegistry {
 
-	/**
-	 * Base interface for events.<br>
-	 * <br>
-	 * To create a new event, create an interface and extend EventBase.<br>
-	 * Only 1 method is accepted in an event, so it's best to add
-	 * {@link FunctionalInterface} to the interface.<br>
-	 * <br>
-	 * Example:
-	 * 
-	 * <pre>
-	 * &#64;FunctionalInterface
-	 * public interface EventInit extends EventBase {
-	 * 	public void onEventInit();
-	 * }
-	 *
-	 * &#64;FunctionalInterface
-	 * public interface EventAdd extends EventBase {
-	 * 	public int onEventAdd(int a, int b); // Accepts parameters and return types
-	 * }
-	 * </pre>
-	 *
-	 * To fire your event, use {@link EventListenerRegistry#fireEvent(Class)} with
-	 * the parameter being the event class.<br>
-	 *
-	 * <pre>
-	 * EventListenerRegistry.fireEvent(EventInit.class);
-	 * </pre>
-	 *
-	 * To fire an event with parameters and return types:
-	 * 
-	 * <pre>
-	 * int eventResult = (int) EventListenerRegistry.fireEvent(EventAdd.class, a, b);
-	 * </pre>
-	 * 
-	 * When using parameters, the type and the amount of parameters has to match!
-	 */
-	public interface EventBase {
-	}
+    /**
+     * Base interface for events.<br>
+     * <br>
+     * To create a new event, create an interface and extend EventBase.<br>
+     * Only 1 method is accepted in an event, so it's best to add {@link FunctionalInterface} to the interface.<br>
+     * <br>
+     * Example:
+     * <pre>
+     *     @ FunctionalInterface
+     *     public interface EventInit extends EventBase {
+     *         public void onEventInit();
+     *     }
+     *
+     *     @ FunctionalInterface
+     *     public interface EventAdd extends EventBase {
+     *         public int onEventAdd(int a, int b); // Accepts parameters and return types
+     *     }
+     * </pre>
+     *
+     * To fire your event, use {@link EventListenerRegistry#fireEvent(Class)} with the parameter being the event class.<br>
+     *
+     * <pre>
+     *     EventListenerRegistry.fireEvent(EventInit.class);
+     * </pre>
+     *
+     * To fire an event with parameters and return types:
+     * <pre>
+     *     int eventResult = (int) EventListenerRegistry.fireEvent(EventAdd.class, a, b);
+     * </pre>
+     * When using parameters, the type and the amount of parameters has to match!
+     */
+    public interface EventBase {
+    }
 
-	/**
-	 * Stores the event listener objects and calls their event methods during
-	 * {@link EventListenerRegistry#fireEvent(Class, Object...)}<br>
-	 * <br>
-	 * Consists of multiple lists seperated by event types.<br>
-	 * If it were a single ArrayList, firing an event means that you'd have to
-	 * unnecessarily iterate over the entire list,<br>
-	 * to find the correct events.<br>
-	 * <br>
-	 * With multiple lists like this, you iterate only over the objects, that have
-	 * the correct event applied.
-	 */
-	private static final HashMap<Class<?>, ArrayList<EventBase>> EVENTLISTENER_REGISTRY = new HashMap<>();
+    /**
+     * Stores the event listener objects and calls their event methods during {@link EventListenerRegistry#fireEvent(Class, Object...)}<br>
+     * <br>
+     * Consists of multiple lists seperated by event types.<br>
+     * If it were a single ArrayList, firing an event means that you'd have to unnecessarily iterate over the entire list,<br>
+     * to find the correct events.<br>
+     * <br>
+     * With multiple lists like this, you iterate only over the objects, that have the correct event applied.
+     */
+    private static final HashMap<Class<?>, ArrayList<EventBase>> EVENTLISTENER_REGISTRY = new HashMap<>();
 
-	/**
-	 * Registers an object to be an event listener. The object must implement an
-	 * event extending {@link EventBase}
-	 * 
-	 * @param eventListener The event listener to register
-	 */
-	public static void register(EventBase eventListener) {
-		if (eventListener == null) {
-			throw new NullPointerException("Tried to register a packethandler with value null");
-		}
-		for (Class<?> type : eventListener.getClass().getInterfaces()) {
-			if (EventBase.class.isAssignableFrom(type)) {
+    /**
+     * Registers an object to be an event listener. The object must implement an event extending {@link EventBase}
+     * @param eventListener The event listener to register
+     */
+    public static void register(EventBase eventListener) {
+        if (eventListener == null) {
+            throw new NullPointerException("Tried to register a packethandler with value null");
+        }
+        for (Class<?> type : eventListener.getClass().getInterfaces()) {
+            if (EventBase.class.isAssignableFrom(type)) {
 
                 // If a new event type is being registered, add a new arraylist
                 ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.putIfAbsent(type, new ArrayList<>());
@@ -117,20 +105,19 @@ public class EventListenerRegistry {
     	}
     }
 
-	/**
-	 * Unregisters an object from being an event listener.
-	 * 
-	 * @param eventListener The event listener to unregister
-	 */
-	public static void unregister(EventBase eventListener) {
-		if (eventListener == null) {
-			throw new NullPointerException("Tried to unregister a packethandler with value null");
-		}
-		for (Class<?> type : eventListener.getClass().getInterfaces()) {
-			if (EventBase.class.isAssignableFrom(type)) {
-				ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.get(type);
-				if (registryList != null) {
-					registryList.remove(eventListener);
+    /**
+     * Unregisters an object from being an event listener.
+     * @param eventListener The event listener to unregister
+     */
+    public static void unregister(EventBase eventListener) {
+        if (eventListener == null) {
+            throw new NullPointerException("Tried to unregister a packethandler with value null");
+        }
+        for (Class<?> type : eventListener.getClass().getInterfaces()) {
+            if (EventBase.class.isAssignableFrom(type)) {
+                ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.get(type);
+                if (registryList != null) {
+                    registryList.remove(eventListener);
 
                     if (registryList.isEmpty()) {
                         EVENTLISTENER_REGISTRY.remove(type);
@@ -150,150 +137,140 @@ public class EventListenerRegistry {
     	}
     }
 
-	/**
-	 * Fires an event without parameters
-	 *
-	 * @param eventClass The event class to fire e.g. EventClientInit.class
-	 * @return The result of the event, might be null if the event returns nothing
-	 */
-	public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass) {
-		return fireEvent(eventClass, new Object[] {});
-	}
+    /**
+     * Fires an event without parameters
+     *
+     * @param eventClass The event class to fire e.g. EventClientInit.class
+     * @return The result of the event, might be null if the event returns nothing
+     */
+    public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass) {
+        return fireEvent(eventClass, new Object[]{});
+    }
 
-	/**
-	 * Fires an event with parameters
-	 *
-	 * @param eventClass  The event class to fire e.g. EventClientInit.class
-	 * @param eventParams List of parameters for the event. Number of arguments and
-	 *                    types have to match.
-	 * @return The result of the event, might be null if the event returns nothing
-	 */
-	public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass, Object... eventParams) {
-		ArrayList<EventBase> listenerList = EVENTLISTENER_REGISTRY.get(eventClass);
-		if (listenerList == null) {
-			return null;
-		}
+    /**
+     * Fires an event with parameters
+     *
+     * @param eventClass  The event class to fire e.g. EventClientInit.class
+     * @param eventParams List of parameters for the event. Number of arguments and types have to match.
+     * @return The result of the event, might be null if the event returns nothing
+     */
+    public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass, Object... eventParams) {
+        ArrayList<EventBase> listenerList = EVENTLISTENER_REGISTRY.get(eventClass);
+        if (listenerList == null) {
+            throw new EventException("The event has not been registered yet", eventClass);
+        }
 
-		// Exception to be thrown at the end of the method. If null then no exception is
-		// thrown
-		EventException toThrow = null;
+        // Exception to be thrown at the end of the method. If null then no exception is thrown
+        EventException toThrow = null;
 
-		// Get the method from the event that we are looking for in the event listeners
-		Method methodToFind = getEventMethod(eventClass);
+        // Get the method from the event that we are looking for in the event listeners
+        Method methodToFind = getEventMethod(eventClass);
 
-		// Variable for the return value. The last registered listener will return its
-		// value
-		Object returnValue = null;
+        // Variable for the return value. The last registered listener will return its value
+        Object returnValue = null;
 
-		// Iterate through the list of eventListeners
-		for (EventBase eventListener : listenerList) {
-			// Get all methods in this event listener
-			Method[] methodsInListener = eventListener.getClass().getDeclaredMethods();
+        // Iterate through the list of eventListeners
+        for (EventBase eventListener : listenerList) {
+            // Get all methods in this event listener
+            Method[] methodsInListener = eventListener.getClass().getDeclaredMethods();
 
-			// Iterate through all methods
-			for (Method method : methodsInListener) {
+            // Iterate through all methods
+            for (Method method : methodsInListener) {
 
-				// Check if the current method has the same name as the method we are looking
-				// for
-				if (!checkName(method, methodToFind.getName())) {
-					continue;
-				}
+                // Check if the current method has the same name as the method we are looking for
+                if (!checkName(method, methodToFind.getName())) {
+                    continue;
+                }
 
-				// Check if the length is the same before we check for types
-				if (!checkLength(method, eventParams)) {
-					toThrow = new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass);
-					continue;
-				}
+                // Check if the length is the same before we check for types
+                if (!checkLength(method, eventParams)) {
+                    toThrow = new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass);
+                    continue;
+                }
 
-				// Check the types of the method
-				if (checkTypes(method, eventParams)) {
-					toThrow = null; // Reset toThrow as the correct method was found
-					method.setAccessible(true);
-					try {
-						returnValue = method.invoke(eventListener, eventParams); // Call the method
-					} catch (IllegalAccessException | InvocationTargetException e) {
-						throw new EventException(eventClass, e);
-					} catch (IllegalArgumentException e) {
-						throw new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass, e);
-					}
-				} else {
-					toThrow = new EventException("Event seems to be fired with the wrong parameter types or in the wrong order", eventClass);
-				}
-			}
-		}
+                // Check the types of the method
+                if (checkTypes(method, eventParams)) {
+                    toThrow = null;     // Reset toThrow as the correct method was found
+                    method.setAccessible(true);
+                    try {
+                        returnValue = method.invoke(eventListener, eventParams); // Call the method
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        throw new EventException(eventClass, e);
+                    } catch (IllegalArgumentException e) {
+                        throw new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass, e);
+                    }
+                } else {
+                    toThrow = new EventException("Event seems to be fired with the wrong parameter types or in the wrong order", eventClass);
+                }
+            }
+        }
 
-		// Throw the exception
-		if (toThrow != null) {
-			throw toThrow;
-		}
+        // Throw the exception
+        if (toThrow != null) {
+            throw toThrow;
+        }
 
-		return returnValue;
-	}
+        return returnValue;
+    }
 
-	private static Method getEventMethod(Class<? extends EventListenerRegistry.EventBase> eventClass) {
-		Method[] test = eventClass.getDeclaredMethods();
-		if (test.length != 1) {
-			throw new EventException("The event method is not properly defined. Only one method is allowed inside of an event", eventClass);
-		}
+    private static Method getEventMethod(Class<? extends EventListenerRegistry.EventBase> eventClass) {
+        Method[] test = eventClass.getDeclaredMethods();
+        if (test.length != 1) {
+            throw new EventException("The event method is not properly defined. Only one method is allowed inside of an event", eventClass);
+        }
 
-		return test[0];
-	}
+        return test[0];
+    }
 
-	/**
-	 * @param method The method to check
-	 * @param name   The name to check
-	 * @return If method.getName equals name
-	 */
-	private static boolean checkName(Method method, String name) {
-		return method.getName().equals(name);
-	}
+    /**
+     * @param method The method to check
+     * @param name The name to check
+     * @return If method.getName equals name
+     */
+    private static boolean checkName(Method method, String name) {
+        return method.getName().equals(name);
+    }
 
-	/**
-	 * @param method     The method to check
-	 * @param parameters The list of parameters
-	 * @return True, if length of the method parameters is equal to the length of
-	 *         the object parameters
-	 */
-	private static boolean checkLength(Method method, Object... parameters) {
-		return method.getParameterCount() == parameters.length;
-	}
+    /**
+     * @param method The method to check
+     * @param parameters The list of parameters
+     * @return True, if length of the method parameters is equal to the length of the object parameters
+     */
+    private static boolean checkLength(Method method, Object... parameters) {
+        return method.getParameterCount() == parameters.length;
+    }
 
-	/**
-	 * @param method     The method to check
-	 * @param parameters The list of parameters
-	 * @return True, if the types of the parameters equal the object parameters
-	 */
-	private static boolean checkTypes(Method method, Object... parameters) {
-		Class<?>[] methodParameterTypes = ClassUtils.primitivesToWrappers(method.getParameterTypes());
-		Class<?>[] eventParameterTypes = getParameterTypes(parameters);
+    /**
+     * @param method The method to check
+     * @param parameters The list of parameters
+     * @return True, if the types of the parameters equal the object parameters
+     */
+    private static boolean checkTypes(Method method, Object... parameters) {
+        Class<?>[] methodParameterTypes = ClassUtils.primitivesToWrappers(method.getParameterTypes());
+        Class<?>[] eventParameterTypes = getParameterTypes(parameters);
 
-		for (int i = 0; i < methodParameterTypes.length; i++) {
-			Class<?> paramName = methodParameterTypes[i];
-			Class<?> eventName = eventParameterTypes[i];
+        for (int i = 0; i < methodParameterTypes.length; i++) {
+            Class<?> paramName = methodParameterTypes[i];
+            Class<?> eventName = eventParameterTypes[i];
+            if (!paramName.equals(eventName)) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-			if (paramName == null || eventName == null) {
-				continue;
-			}
+    private static Class<?>[] getParameterTypes(Object... parameters) {
+        Class<?>[] out = new Class[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            out[i] = parameters[i].getClass();
+        }
+        return out;
+    }
 
-			if (!paramName.equals(eventName) && !paramName.isAssignableFrom(eventName)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	private static Class<?>[] getParameterTypes(Object... parameters) {
-		Class<?>[] out = new Class[parameters.length];
-		for (int i = 0; i < parameters.length; i++) {
-			out[i] = parameters[i] == null ? null : parameters[i].getClass();
-		}
-		return out;
-	}
-
-	/**
-	 * Removes all registry entries
-	 */
-	public static void clear() {
-		EVENTLISTENER_REGISTRY.clear();
-	}
+    /**
+     * Removes all registry entries
+     */
+    public static void clear() {
+        EVENTLISTENER_REGISTRY.clear();
+    }
 }

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
@@ -97,15 +97,21 @@ public class EventListenerRegistry {
 		for (Class<?> type : eventListener.getClass().getInterfaces()) {
 			if (EventBase.class.isAssignableFrom(type)) {
 
-				// If a new event type is being registered, add a new arraylist
-				ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.putIfAbsent(type, new ArrayList<>());
-				if (registryList == null) {
-					registryList = EVENTLISTENER_REGISTRY.get(type);
-				}
-				registryList.add(eventListener);
-			}
-		}
-	}
+                // If a new event type is being registered, add a new arraylist
+                ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.putIfAbsent(type, new ArrayList<>());
+                if (registryList == null) {
+                    registryList = EVENTLISTENER_REGISTRY.get(type);
+                }
+                registryList.add(eventListener);
+            }
+        }
+    }
+    
+    public static void register(EventBase... eventListeners) {
+    	for(EventBase eventListener : eventListeners) {
+    		register(eventListener);
+    	}
+    }
 
 	/**
 	 * Unregisters an object from being an event listener.

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventListenerRegistry.java
@@ -12,265 +12,291 @@ import java.util.HashMap;
  * <br>
  * Implement an EventInterface into your class, then implement the function.<br>
  * <br>
- * In your initializer method, register the instance of the class with {@link EventListenerRegistry#register(EventBase)}
- * <br>
+ * In your initializer method, register the instance of the class with
+ * {@link EventListenerRegistry#register(EventBase)} <br>
  * Example:
+ * 
  * <pre>
- *     public class ClassWithListener implements EventInit {
+ * public class ClassWithListener implements EventInit {
  *
- *          @ Override
- *          public void onEventInit() {
- *              // Implement event specific code
- *          }
- *     }
+ * 	&#64;Override
+ * 	public void onEventInit() {
+ * 		// Implement event specific code
+ * 	}
+ * }
  * </pre>
+ * 
  * <br>
  * To create and fire your own events, check {@link EventBase}<br>
  */
 public class EventListenerRegistry {
 
-    /**
-     * Base interface for events.<br>
-     * <br>
-     * To create a new event, create an interface and extend EventBase.<br>
-     * Only 1 method is accepted in an event, so it's best to add {@link FunctionalInterface} to the interface.<br>
-     * <br>
-     * Example:
-     * <pre>
-     *     @ FunctionalInterface
-     *     public interface EventInit extends EventBase {
-     *         public void onEventInit();
-     *     }
-     *
-     *     @ FunctionalInterface
-     *     public interface EventAdd extends EventBase {
-     *         public int onEventAdd(int a, int b); // Accepts parameters and return types
-     *     }
-     * </pre>
-     *
-     * To fire your event, use {@link EventListenerRegistry#fireEvent(Class)} with the parameter being the event class.<br>
-     *
-     * <pre>
-     *     EventListenerRegistry.fireEvent(EventInit.class);
-     * </pre>
-     *
-     * To fire an event with parameters and return types:
-     * <pre>
-     *     int eventResult = (int) EventListenerRegistry.fireEvent(EventAdd.class, a, b);
-     * </pre>
-     * When using parameters, the type and the amount of parameters has to match!
-     */
-    public interface EventBase {
-    }
+	/**
+	 * Base interface for events.<br>
+	 * <br>
+	 * To create a new event, create an interface and extend EventBase.<br>
+	 * Only 1 method is accepted in an event, so it's best to add
+	 * {@link FunctionalInterface} to the interface.<br>
+	 * <br>
+	 * Example:
+	 * 
+	 * <pre>
+	 * &#64;FunctionalInterface
+	 * public interface EventInit extends EventBase {
+	 * 	public void onEventInit();
+	 * }
+	 *
+	 * &#64;FunctionalInterface
+	 * public interface EventAdd extends EventBase {
+	 * 	public int onEventAdd(int a, int b); // Accepts parameters and return types
+	 * }
+	 * </pre>
+	 *
+	 * To fire your event, use {@link EventListenerRegistry#fireEvent(Class)} with
+	 * the parameter being the event class.<br>
+	 *
+	 * <pre>
+	 * EventListenerRegistry.fireEvent(EventInit.class);
+	 * </pre>
+	 *
+	 * To fire an event with parameters and return types:
+	 * 
+	 * <pre>
+	 * int eventResult = (int) EventListenerRegistry.fireEvent(EventAdd.class, a, b);
+	 * </pre>
+	 * 
+	 * When using parameters, the type and the amount of parameters has to match!
+	 */
+	public interface EventBase {
+	}
 
-    /**
-     * Stores the event listener objects and calls their event methods during {@link EventListenerRegistry#fireEvent(Class, Object...)}<br>
-     * <br>
-     * Consists of multiple lists seperated by event types.<br>
-     * If it were a single ArrayList, firing an event means that you'd have to unnecessarily iterate over the entire list,<br>
-     * to find the correct events.<br>
-     * <br>
-     * With multiple lists like this, you iterate only over the objects, that have the correct event applied.
-     */
-    private static final HashMap<Class<?>, ArrayList<EventBase>> EVENTLISTENER_REGISTRY = new HashMap<>();
+	/**
+	 * Stores the event listener objects and calls their event methods during
+	 * {@link EventListenerRegistry#fireEvent(Class, Object...)}<br>
+	 * <br>
+	 * Consists of multiple lists seperated by event types.<br>
+	 * If it were a single ArrayList, firing an event means that you'd have to
+	 * unnecessarily iterate over the entire list,<br>
+	 * to find the correct events.<br>
+	 * <br>
+	 * With multiple lists like this, you iterate only over the objects, that have
+	 * the correct event applied.
+	 */
+	private static final HashMap<Class<?>, ArrayList<EventBase>> EVENTLISTENER_REGISTRY = new HashMap<>();
 
-    /**
-     * Registers an object to be an event listener. The object must implement an event extending {@link EventBase}
-     * @param eventListener The event listener to register
-     */
-    public static void register(EventBase eventListener) {
-        if (eventListener == null) {
-            throw new NullPointerException("Tried to register a packethandler with value null");
-        }
-        for (Class<?> type : eventListener.getClass().getInterfaces()) {
-            if (EventBase.class.isAssignableFrom(type)) {
+	/**
+	 * Registers an object to be an event listener. The object must implement an
+	 * event extending {@link EventBase}
+	 * 
+	 * @param eventListener The event listener to register
+	 */
+	public static void register(EventBase eventListener) {
+		if (eventListener == null) {
+			throw new NullPointerException("Tried to register a packethandler with value null");
+		}
+		for (Class<?> type : eventListener.getClass().getInterfaces()) {
+			if (EventBase.class.isAssignableFrom(type)) {
 
-                // If a new event type is being registered, add a new arraylist
-                ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.putIfAbsent(type, new ArrayList<>());
-                if (registryList == null) {
-                    registryList = EVENTLISTENER_REGISTRY.get(type);
-                }
-                registryList.add(eventListener);
-            }
-        }
-    }
-    
-    /**
-     * Registers multiple objects to be an event listener. The objects must implement an event extending {@link EventBase}
-     * @param eventListeners The event listeners to register
-     */
-    public static void register(EventBase... eventListeners) {
-    	for(EventBase eventListener : eventListeners) {
-    		register(eventListener);
-    	}
-    }
+				// If a new event type is being registered, add a new arraylist
+				ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.putIfAbsent(type, new ArrayList<>());
+				if (registryList == null) {
+					registryList = EVENTLISTENER_REGISTRY.get(type);
+				}
+				registryList.add(eventListener);
+			}
+		}
+	}
 
-    /**
-     * Unregisters an object from being an event listener.
-     * @param eventListener The event listener to unregister
-     */
-    public static void unregister(EventBase eventListener) {
-        if (eventListener == null) {
-            throw new NullPointerException("Tried to unregister a packethandler with value null");
-        }
-        for (Class<?> type : eventListener.getClass().getInterfaces()) {
-            if (EventBase.class.isAssignableFrom(type)) {
-                ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.get(type);
-                if (registryList != null) {
-                    registryList.remove(eventListener);
+	/**
+	 * Registers multiple objects to be an event listener. The objects must
+	 * implement an event extending {@link EventBase}
+	 * 
+	 * @param eventListeners The event listeners to register
+	 */
+	public static void register(EventBase... eventListeners) {
+		for (EventBase eventListener : eventListeners) {
+			register(eventListener);
+		}
+	}
 
-                    if (registryList.isEmpty()) {
-                        EVENTLISTENER_REGISTRY.remove(type);
-                    }
-                }
-            }
-        }
-    }
-    
-    /**
-     * Unregisters multiple objects from being an event listener.
-     * @param eventListener The event listeners to unregister
-     */
-    public static void unregister(EventBase... eventListeners) {
-    	for(EventBase eventListener : eventListeners) {
-    		unregister(eventListener);
-    	}
-    }
+	/**
+	 * Unregisters an object from being an event listener.
+	 * 
+	 * @param eventListener The event listener to unregister
+	 */
+	public static void unregister(EventBase eventListener) {
+		if (eventListener == null) {
+			throw new NullPointerException("Tried to unregister a packethandler with value null");
+		}
+		for (Class<?> type : eventListener.getClass().getInterfaces()) {
+			if (EventBase.class.isAssignableFrom(type)) {
+				ArrayList<EventBase> registryList = EVENTLISTENER_REGISTRY.get(type);
+				if (registryList != null) {
+					registryList.remove(eventListener);
 
-    /**
-     * Fires an event without parameters
-     *
-     * @param eventClass The event class to fire e.g. EventClientInit.class
-     * @return The result of the event, might be null if the event returns nothing
-     */
-    public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass) {
-        return fireEvent(eventClass, new Object[]{});
-    }
+					if (registryList.isEmpty()) {
+						EVENTLISTENER_REGISTRY.remove(type);
+					}
+				}
+			}
+		}
+	}
 
-    /**
-     * Fires an event with parameters
-     *
-     * @param eventClass  The event class to fire e.g. EventClientInit.class
-     * @param eventParams List of parameters for the event. Number of arguments and types have to match.
-     * @return The result of the event, might be null if the event returns nothing
-     */
-    public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass, Object... eventParams) {
-        ArrayList<EventBase> listenerList = EVENTLISTENER_REGISTRY.get(eventClass);
-        if (listenerList == null) {
-            throw new EventException("The event has not been registered yet", eventClass);
-        }
+	/**
+	 * Unregisters multiple objects from being an event listener.
+	 * 
+	 * @param eventListener The event listeners to unregister
+	 */
+	public static void unregister(EventBase... eventListeners) {
+		for (EventBase eventListener : eventListeners) {
+			unregister(eventListener);
+		}
+	}
 
-        // Exception to be thrown at the end of the method. If null then no exception is thrown
-        EventException toThrow = null;
+	/**
+	 * Fires an event without parameters
+	 *
+	 * @param eventClass The event class to fire e.g. EventClientInit.class
+	 * @return The result of the event, might be null if the event returns nothing
+	 */
+	public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass) {
+		return fireEvent(eventClass, new Object[] {});
+	}
 
-        // Get the method from the event that we are looking for in the event listeners
-        Method methodToFind = getEventMethod(eventClass);
+	/**
+	 * Fires an event with parameters
+	 *
+	 * @param eventClass  The event class to fire e.g. EventClientInit.class
+	 * @param eventParams List of parameters for the event. Number of arguments and
+	 *                    types have to match.
+	 * @return The result of the event, might be null if the event returns nothing
+	 */
+	public static Object fireEvent(Class<? extends EventListenerRegistry.EventBase> eventClass, Object... eventParams) {
+		ArrayList<EventBase> listenerList = EVENTLISTENER_REGISTRY.get(eventClass);
+		if (listenerList == null) {
+//            throw new EventException("The event has not been registered yet", eventClass);
+			return null;
+		}
 
-        // Variable for the return value. The last registered listener will return its value
-        Object returnValue = null;
+		// Exception to be thrown at the end of the method. If null then no exception is
+		// thrown
+		EventException toThrow = null;
 
-        // Iterate through the list of eventListeners
-        for (EventBase eventListener : listenerList) {
-            // Get all methods in this event listener
-            Method[] methodsInListener = eventListener.getClass().getDeclaredMethods();
+		// Get the method from the event that we are looking for in the event listeners
+		Method methodToFind = getEventMethod(eventClass);
 
-            // Iterate through all methods
-            for (Method method : methodsInListener) {
+		// Variable for the return value. The last registered listener will return its
+		// value
+		Object returnValue = null;
 
-                // Check if the current method has the same name as the method we are looking for
-                if (!checkName(method, methodToFind.getName())) {
-                    continue;
-                }
+		// Iterate through the list of eventListeners
+		for (EventBase eventListener : listenerList) {
+			// Get all methods in this event listener
+			Method[] methodsInListener = eventListener.getClass().getDeclaredMethods();
 
-                // Check if the length is the same before we check for types
-                if (!checkLength(method, eventParams)) {
-                    toThrow = new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass);
-                    continue;
-                }
+			// Iterate through all methods
+			for (Method method : methodsInListener) {
 
-                // Check the types of the method
-                if (checkTypes(method, eventParams)) {
-                    toThrow = null;     // Reset toThrow as the correct method was found
-                    method.setAccessible(true);
-                    try {
-                        returnValue = method.invoke(eventListener, eventParams); // Call the method
-                    } catch (IllegalAccessException | InvocationTargetException e) {
-                        throw new EventException(eventClass, e);
-                    } catch (IllegalArgumentException e) {
-                        throw new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass, e);
-                    }
-                } else {
-                    toThrow = new EventException("Event seems to be fired with the wrong parameter types or in the wrong order", eventClass);
-                }
-            }
-        }
+				// Check if the current method has the same name as the method we are looking
+				// for
+				if (!checkName(method, methodToFind.getName())) {
+					continue;
+				}
 
-        // Throw the exception
-        if (toThrow != null) {
-            throw toThrow;
-        }
+				// Check if the length is the same before we check for types
+				if (!checkLength(method, eventParams)) {
+					toThrow = new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass);
+					continue;
+				}
 
-        return returnValue;
-    }
+				// Check the types of the method
+				if (checkTypes(method, eventParams)) {
+					toThrow = null; // Reset toThrow as the correct method was found
+					method.setAccessible(true);
+					try {
+						returnValue = method.invoke(eventListener, eventParams); // Call the method
+					} catch (IllegalAccessException | InvocationTargetException e) {
+						throw new EventException(eventClass, e);
+					} catch (IllegalArgumentException e) {
+						throw new EventException(String.format("Event fired with the wrong number of parameters. Expected: %s, Actual: %s", method.getParameterCount(), eventParams.length), eventClass, e);
+					}
+				} else {
+					toThrow = new EventException("Event seems to be fired with the wrong parameter types or in the wrong order", eventClass);
+				}
+			}
+		}
 
-    private static Method getEventMethod(Class<? extends EventListenerRegistry.EventBase> eventClass) {
-        Method[] test = eventClass.getDeclaredMethods();
-        if (test.length != 1) {
-            throw new EventException("The event method is not properly defined. Only one method is allowed inside of an event", eventClass);
-        }
+		// Throw the exception
+		if (toThrow != null) {
+			throw toThrow;
+		}
 
-        return test[0];
-    }
+		return returnValue;
+	}
 
-    /**
-     * @param method The method to check
-     * @param name The name to check
-     * @return If method.getName equals name
-     */
-    private static boolean checkName(Method method, String name) {
-        return method.getName().equals(name);
-    }
+	private static Method getEventMethod(Class<? extends EventListenerRegistry.EventBase> eventClass) {
+		Method[] test = eventClass.getDeclaredMethods();
+		if (test.length != 1) {
+			throw new EventException("The event method is not properly defined. Only one method is allowed inside of an event", eventClass);
+		}
 
-    /**
-     * @param method The method to check
-     * @param parameters The list of parameters
-     * @return True, if length of the method parameters is equal to the length of the object parameters
-     */
-    private static boolean checkLength(Method method, Object... parameters) {
-        return method.getParameterCount() == parameters.length;
-    }
+		return test[0];
+	}
 
-    /**
-     * @param method The method to check
-     * @param parameters The list of parameters
-     * @return True, if the types of the parameters equal the object parameters
-     */
-    private static boolean checkTypes(Method method, Object... parameters) {
-        Class<?>[] methodParameterTypes = ClassUtils.primitivesToWrappers(method.getParameterTypes());
-        Class<?>[] eventParameterTypes = getParameterTypes(parameters);
+	/**
+	 * @param method The method to check
+	 * @param name   The name to check
+	 * @return If method.getName equals name
+	 */
+	private static boolean checkName(Method method, String name) {
+		return method.getName().equals(name);
+	}
 
-        for (int i = 0; i < methodParameterTypes.length; i++) {
-            Class<?> paramName = methodParameterTypes[i];
-            Class<?> eventName = eventParameterTypes[i];
-            if (!paramName.equals(eventName)) {
-                return false;
-            }
-        }
-        return true;
-    }
+	/**
+	 * @param method     The method to check
+	 * @param parameters The list of parameters
+	 * @return True, if length of the method parameters is equal to the length of
+	 *         the object parameters
+	 */
+	private static boolean checkLength(Method method, Object... parameters) {
+		return method.getParameterCount() == parameters.length;
+	}
 
-    private static Class<?>[] getParameterTypes(Object... parameters) {
-        Class<?>[] out = new Class[parameters.length];
-        for (int i = 0; i < parameters.length; i++) {
-            out[i] = parameters[i].getClass();
-        }
-        return out;
-    }
+	/**
+	 * @param method     The method to check
+	 * @param parameters The list of parameters
+	 * @return True, if the types of the parameters equal the object parameters
+	 */
+	private static boolean checkTypes(Method method, Object... parameters) {
+		Class<?>[] methodParameterTypes = ClassUtils.primitivesToWrappers(method.getParameterTypes());
+		Class<?>[] eventParameterTypes = getParameterTypes(parameters);
 
-    /**
-     * Removes all registry entries
-     */
-    public static void clear() {
-        EVENTLISTENER_REGISTRY.clear();
-    }
+		for (int i = 0; i < methodParameterTypes.length; i++) {
+			Class<?> paramName = methodParameterTypes[i];
+			Class<?> eventName = eventParameterTypes[i];
+			if (!paramName.equals(eventName) && (paramName != null && eventName != null && !paramName.isAssignableFrom(eventName))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static Class<?>[] getParameterTypes(Object... parameters) {
+		Class<?>[] out = new Class[parameters.length];
+		for (int i = 0; i < parameters.length; i++) {
+			if (parameters[i] == null) {
+				out[i] = null;
+				continue;
+			}
+			out[i] = parameters[i].getClass();
+		}
+		return out;
+	}
+
+	/**
+	 * Removes all registry entries
+	 */
+	public static void clear() {
+		EVENTLISTENER_REGISTRY.clear();
+	}
 }

--- a/src/main/java/com/minecrafttas/mctcommon/server/PacketHandlerRegistry.java
+++ b/src/main/java/com/minecrafttas/mctcommon/server/PacketHandlerRegistry.java
@@ -41,7 +41,7 @@ public class PacketHandlerRegistry {
 		if (REGISTRY.contains(handler)) {
 			REGISTRY.remove(handler);
 		} else {
-			MCTCommon.LOGGER.warn("Trying to unregister packet handler {}, but is was not registered!", handler.getClass().getName());
+			MCTCommon.LOGGER.warn("Trying to unregister packet handler {}, but it was not registered!", handler.getClass().getName());
 		}
 	}
 

--- a/src/main/java/com/minecrafttas/mctcommon/server/PacketHandlerRegistry.java
+++ b/src/main/java/com/minecrafttas/mctcommon/server/PacketHandlerRegistry.java
@@ -18,15 +18,15 @@ public class PacketHandlerRegistry {
 	private static final List<PacketHandlerBase> REGISTRY = new ArrayList<>();
 
 	public static void register(PacketHandlerBase handler) {
-		if(handler==null) {
+		if (handler == null) {
 			throw new NullPointerException("Tried to register a handler with value null");
 		}
-		
-		if(containsClass(handler)) {
+
+		if (containsClass(handler)) {
 			MCTCommon.LOGGER.warn("Trying to register packet handler {}, but another instance of this class is already registered!", handler.getClass().getName());
 			return;
 		}
-		
+
 		if (!REGISTRY.contains(handler)) {
 			REGISTRY.add(handler);
 		} else {
@@ -35,7 +35,7 @@ public class PacketHandlerRegistry {
 	}
 
 	public static void unregister(PacketHandlerBase handler) {
-		if(handler==null) {
+		if (handler == null) {
 			throw new NullPointerException("Tried to unregister a handler with value null");
 		}
 		if (REGISTRY.contains(handler)) {
@@ -65,14 +65,14 @@ public class PacketHandlerRegistry {
 				}
 			}
 		}
-		if(!isImplemented) {
+		if (!isImplemented) {
 			throw new PacketNotImplementedException(packet, side);
 		}
 	}
-	
+
 	private static boolean containsClass(PacketHandlerBase handler) {
-		for(PacketHandlerBase packethandler : REGISTRY) {
-			if(packethandler.getClass().equals(handler.getClass())) {
+		for (PacketHandlerBase packethandler : REGISTRY) {
+			if (packethandler.getClass().equals(handler.getClass())) {
 				return true;
 			}
 		}

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -27,6 +27,7 @@ import com.minecrafttas.tasmod.commands.CommandTickrate;
 import com.minecrafttas.tasmod.ktrng.KillTheRNGHandler;
 import com.minecrafttas.tasmod.networking.TASmodPackets;
 import com.minecrafttas.tasmod.playback.PlaybackControllerServer;
+import com.minecrafttas.tasmod.playback.metadata.integrated.StartpositionMetadataExtension;
 import com.minecrafttas.tasmod.savestates.SavestateHandlerServer;
 import com.minecrafttas.tasmod.savestates.files.SavestateTrackerFile;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerServer;
@@ -68,6 +69,8 @@ public class TASmod implements ModInitializer, EventServerInit, EventServerStop{
 
 	public static final boolean isDevEnvironment = FabricLoaderImpl.INSTANCE.isDevelopmentEnvironment();
 	
+	public static final StartpositionMetadataExtension startPositionMetadataExtension = new StartpositionMetadataExtension();
+	
 	@Override
 	public void onInitialize() {
 		
@@ -96,6 +99,7 @@ public class TASmod implements ModInitializer, EventServerInit, EventServerStop{
 		PacketHandlerRegistry.register(tickratechanger);
 		PacketHandlerRegistry.register(ktrngHandler);
 		PacketHandlerRegistry.register(playbackControllerServer);
+		PacketHandlerRegistry.register(startPositionMetadataExtension);
 	}
 	
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -153,6 +153,7 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 			}
 			return gui;
 		}));
+		EventListenerRegistry.register(controller);
 		
 		// Register packet handlers
 		LOGGER.info(LoggerMarkers.Networking, "Registering network handlers on client");

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -30,6 +30,7 @@ import com.minecrafttas.tasmod.playback.PlaybackControllerClient;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadataRegistry;
 import com.minecrafttas.tasmod.playback.metadata.integrated.CreditsMetadataExtension;
+import com.minecrafttas.tasmod.playback.metadata.integrated.StartpositionMetadataExtension;
 import com.minecrafttas.tasmod.playback.tasfile.PlaybackSerialiser;
 import com.minecrafttas.tasmod.savestates.SavestateHandlerClient;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerClient;
@@ -89,6 +90,8 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 	public static Client client;
 	
 	public static CreditsMetadataExtension creditsMetadataExtension = new CreditsMetadataExtension();
+	
+	public static StartpositionMetadataExtension startpositionMetadataExtension = new StartpositionMetadataExtension();
 	/**
 	 * The container where all inputs get stored during recording or stored and
 	 * ready to be played back
@@ -160,6 +163,9 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		EventListenerRegistry.register(controller);
 		PlaybackMetadataRegistry.register(creditsMetadataExtension);
 		EventListenerRegistry.register(creditsMetadataExtension);
+		
+		PlaybackMetadataRegistry.register(startpositionMetadataExtension);
+		EventListenerRegistry.register(startpositionMetadataExtension);
 		
 		// Register packet handlers
 		LOGGER.info(LoggerMarkers.Networking, "Registering network handlers on client");

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -28,7 +28,9 @@ import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
 import com.minecrafttas.tasmod.networking.TASmodPackets;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
-import com.minecrafttas.tasmod.playback.PlaybackSerialiser;
+import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadataRegistry;
+import com.minecrafttas.tasmod.playback.metadata.integrated.CreditsMetadataExtension;
+import com.minecrafttas.tasmod.playback.tasfile.PlaybackSerialiser;
 import com.minecrafttas.tasmod.savestates.SavestateHandlerClient;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerClient;
 import com.minecrafttas.tasmod.ticksync.TickSyncClient;
@@ -85,6 +87,8 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 	public static SavestateHandlerClient savestateHandlerClient = new SavestateHandlerClient();
 	
 	public static Client client;
+	
+	public static CreditsMetadataExtension creditsMetadataExtension = new CreditsMetadataExtension();
 	/**
 	 * The container where all inputs get stored during recording or stored and
 	 * ready to be played back
@@ -154,6 +158,8 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 			return gui;
 		}));
 		EventListenerRegistry.register(controller);
+		PlaybackMetadataRegistry.register(creditsMetadataExtension);
+		EventListenerRegistry.register(creditsMetadataExtension);
 		
 		// Register packet handlers
 		LOGGER.info(LoggerMarkers.Networking, "Registering network handlers on client");

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -196,14 +196,15 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		})));
 		blockedKeybindings.add(keybindManager.registerKeybind(new Keybind("Open InfoGui Editor", "TASmod", Keyboard.KEY_F6, () -> Minecraft.getMinecraft().displayGuiScreen(TASmodClient.hud))));
 		blockedKeybindings.add(keybindManager.registerKeybind(new Keybind("Various Testing", "TASmod", Keyboard.KEY_F12, () -> {
-			TASmodClient.client.disconnect();
+			controller.setTASState(TASstate.RECORDING);
 		}, VirtualKeybindings::isKeyDown)));
 		blockedKeybindings.add(keybindManager.registerKeybind(new Keybind("Various Testing2", "TASmod", Keyboard.KEY_F7, () -> {
-			try {
-				TASmodClient.client = new Client("localhost", TASmod.networkingport-1, TASmodPackets.values(), mc.getSession().getProfile().getName(), true);
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
+//			try {
+//				TASmodClient.client = new Client("localhost", TASmod.networkingport-1, TASmodPackets.values(), mc.getSession().getProfile().getName(), true);
+//			} catch (Exception e) {
+//				e.printStackTrace();
+//			}
+			controller.setTASState(TASstate.PLAYBACK);
 		}, VirtualKeybindings::isKeyDown)));
 		blockedKeybindings.forEach(VirtualKeybindings::registerBlockedKeyBinding);
 		

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandLoadTAS.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandLoadTAS.java
@@ -33,6 +33,7 @@ public class CommandLoadTAS extends CommandBase {
 
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+		sender.sendMessage(new TextComponentString(TextFormatting.RED + "This feature does not work at the moment!"));
 		if (sender instanceof EntityPlayer) {
 			if (sender.canUseCommand(2, "load")) {
 				if (args.length < 1) {

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandPlay.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandPlay.java
@@ -38,7 +38,6 @@ public class CommandPlay extends CommandBase {
 
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-		sender.sendMessage(new TextComponentString(TextFormatting.RED + "This feature doesn't work at the moment!"));
 		if (!(sender instanceof EntityPlayer)) {
 			return;
 		}

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandRecord.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandRecord.java
@@ -38,7 +38,6 @@ public class CommandRecord extends CommandBase {
 
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-		sender.sendMessage(new TextComponentString(TextFormatting.RED + "This feature doesn't work at the moment!"));
 		if (!(sender instanceof EntityPlayer)) {
 			return;
 		}

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandSaveTAS.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandSaveTAS.java
@@ -41,6 +41,7 @@ public class CommandSaveTAS extends CommandBase {
 
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+		sender.sendMessage(new TextComponentString(TextFormatting.RED + "This feature does not work at the moment!"));
 		if (sender instanceof EntityPlayer) {
 			if (sender.canUseCommand(2, "save")) {
 				if (args.length < 1) {

--- a/src/main/java/com/minecrafttas/tasmod/events/EventClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/EventClient.java
@@ -1,6 +1,13 @@
 package com.minecrafttas.tasmod.events;
 
 import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
+import com.minecrafttas.tasmod.virtual.VirtualCameraAngle;
+import com.minecrafttas.tasmod.virtual.VirtualInput.VirtualCameraAngleInput;
+import com.minecrafttas.tasmod.virtual.VirtualInput.VirtualKeyboardInput;
+import com.minecrafttas.tasmod.virtual.VirtualInput.VirtualMouseInput;
+import com.minecrafttas.tasmod.virtual.VirtualKeyboard;
+import com.minecrafttas.tasmod.virtual.VirtualMouse;
+
 import net.minecraft.client.Minecraft;
 
 /**
@@ -9,39 +16,94 @@ import net.minecraft.client.Minecraft;
  * @author Scribble
  */
 public interface EventClient {
-	
+
 	/**
 	 * Fired when the hotbar is drawn on screen
 	 */
 	@FunctionalInterface
-	public static interface EventDrawHotbar extends EventBase{
+	public static interface EventDrawHotbar extends EventBase {
 		/**
 		 * Fired when the hotbar is drawn on screen
 		 */
 		public void onDrawHotbar();
 	}
-	
+
 	/**
 	 * Fired at the end of a client tick
 	 */
 	@FunctionalInterface
-	public static interface EventClientTickPost extends EventBase{
-		
+	public static interface EventClientTickPost extends EventBase {
+
 		/**
 		 * Fired at the end of a client tick
 		 */
 		public void onClientTickPost(Minecraft mc);
 	}
-	
+
 	/**
 	 * Fired when the tickrate changes on the client side
 	 */
 	@FunctionalInterface
-	public static interface EventClientTickrateChange extends EventBase{
-		
+	public static interface EventClientTickrateChange extends EventBase {
+
 		/**
 		 * Fired at the end of a client tick
 		 */
 		public void onClientTickrateChange(float tickrate);
+	}
+
+	
+	/**
+	 * Fired when the {@link VirtualKeyboardInput#currentKeyboard} is updated
+	 * 
+	 * @see VirtualKeyboardInput#nextKeyboardTick()
+	 */
+	@FunctionalInterface
+	public static interface EventVirtualKeyboardTick extends EventBase {
+		
+		/**
+		 * Fired when the {@link VirtualKeyboard} ticks
+		 * 
+		 * @param vkeyboard The {@link VirtualKeyboardInput#nextKeyboard} that is supposed to be pressed
+		 * @returns The redirected keyboard
+		 * @see VirtualKeyboardInput#nextKeyboardTick()
+		 */
+		public VirtualKeyboard onVirtualKeyboardTick(VirtualKeyboard vkeyboard);
+	}
+	
+	/**
+	 * Fired when the {@link VirtualMouseInput#currentMouse} is updated
+	 * 
+	 * @see VirtualMouseInput#nextMouseTick()
+	 */
+	@FunctionalInterface
+	public static interface EventVirtualMouseTick extends EventBase {
+		
+		/**
+		 * Fired when the {@link VirtualMouseInput#currentMouse} is updated
+		 * 
+		 * @param vmouse The {@link VirtualMouseInput#nextMouse} that is supposed to be pressed
+		 * @returns The redirected mouse
+		 * @see VirtualMouseInput#nextMouseTick()
+		 */
+		public VirtualMouse onVirtualMouseTick(VirtualMouse vmouse);
+	}
+	
+	/**
+	 * Fired when the {@link VirtualCameraAngleInput#currentCameraAngle} is updated
+	 * 
+	 * @see VirtualCameraAngleInput#nextCameraTick()
+	 */
+	@FunctionalInterface
+	public static interface EventVirtualCameraAngleTick extends EventBase {
+		
+		/**
+		 * Fired when the {@link VirtualCameraAngleInput#currentCameraAngle} is updated
+		 * 
+		 * @param vcamera The {@link VirtualCameraAngleInput#nextCameraAngle}
+		 * @returns The redirected cameraAngle
+		 * @see VirtualCameraAngleInput#nextCameraTick()
+		 */
+		public VirtualCameraAngle onVirtualCameraTick(VirtualCameraAngle vcamera);
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/events/EventPlaybackClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/EventPlaybackClient.java
@@ -1,0 +1,37 @@
+package com.minecrafttas.tasmod.events;
+
+import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient;
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
+
+public interface EventPlaybackClient {
+
+	/**
+	 * Fired when
+	 * {@link PlaybackControllerClient#setTASStateClient(com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate, boolean)}
+	 * is called
+	 */
+	@FunctionalInterface
+	public static interface EventControllerStateChange extends EventBase {
+
+		/**
+		 * Fired when
+		 * {@link PlaybackControllerClient#setTASStateClient(com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate, boolean)}
+		 * is called
+		 * 
+		 * @param newstate The new state that the playback controller is about to be set
+		 *                 to
+		 * @param oldstate The current state that is about to be replaced by newstate
+		 */
+		public void onControllerStateChange(TASstate newstate, TASstate oldstate);
+	}
+
+	/**
+	 * Fired after a player joined the world with a playback/recording running
+	 */
+	@FunctionalInterface
+	public static interface EventPlaybackJoinedWorld extends EventBase {
+		
+		public void onPlaybackJoinedWorld(TASstate state);
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/gui/InfoHud.java
+++ b/src/main/java/com/minecrafttas/tasmod/gui/InfoHud.java
@@ -17,17 +17,14 @@ import com.minecrafttas.mctcommon.events.EventClient.EventClientTick;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.TASmodClient;
 import com.minecrafttas.tasmod.events.EventClient.EventDrawHotbar;
-import com.minecrafttas.tasmod.handlers.InterpolationHandler;
 import com.minecrafttas.tasmod.monitoring.DesyncMonitoring;
 import com.minecrafttas.tasmod.playback.ControlByteHandler;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
-import com.minecrafttas.tasmod.util.TrajectoriesCalculator;
 import com.mojang.realmsclient.gui.ChatFormatting;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.ScaledResolution;
-import net.minecraft.util.math.Vec3d;
 
 /**
  * The info hud is a hud that is always being rendered ontop of the screen, it can show some stuff such as coordinates, etc.,

--- a/src/main/java/com/minecrafttas/tasmod/handlers/InterpolationHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/handlers/InterpolationHandler.java
@@ -26,8 +26,8 @@ public class InterpolationHandler implements EventCamera {
 			TickInputContainer input = TASmodClient.controller.get();
 			if (input == null)
 				return dataIn;
-			float nextPitch = input.getSubticks().getPitch();
-			float nextYaw = input.getSubticks().getYaw();
+			float nextPitch = input.getCameraAngle().getPitch();
+			float nextYaw = input.getCameraAngle().getYaw();
 			dataIn.pitch = (float) MathHelper.clampedLerp(rotationPitch, nextPitch, Minecraft.getMinecraft().timer.renderPartialTicks);
 			dataIn.yaw = (float) MathHelper.clampedLerp(rotationYaw, nextYaw + 180, Minecraft.getMinecraft().timer.renderPartialTicks);
 		} else {

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/KillTheRNGHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/KillTheRNGHandler.java
@@ -209,7 +209,7 @@ public class KillTheRNGHandler implements EventServerTick, EventPlayerJoinedClie
 				break;
 
 			case KILLTHERNG_STARTSEED:
-				TASmodClient.controller.setStartSeed(seed);
+//				TASmodClient.controller.setStartSeed(seed);
 				break;
 
 			default:

--- a/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraft.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraft.java
@@ -91,9 +91,4 @@ public abstract class MixinMinecraft {
 	public long fixMouseWheel(long twohundredLong) {
 		return (long) Math.max(4000F / TASmodClient.tickratechanger.ticksPerSecond, 200L);
 	}
-
-	@Inject(method = "runTick", at = @At(value = "RETURN"))
-	public void injectRunTickReturn(CallbackInfo ci) {
-		TASmodClient.controller.nextTick(); // TODO Replace with event
-	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/playbackhooks/MixinEntityRenderer.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/playbackhooks/MixinEntityRenderer.java
@@ -81,7 +81,7 @@ public class MixinEntityRenderer implements SubtickDuck {
 			}
 
 			mc.getTutorial().handleMouse(mc.mouseHelper);
-			TASmodClient.virtual.CAMERA_ANGLE.updateNextCameraAngle((float) -((double)deltaPitch * 0.15D * invertMouse), (float) ((double)deltaYaw * 0.15D));
+			TASmodClient.virtual.CAMERA_ANGLE.updateNextCameraAngle((float) -((double)deltaPitch * 0.15D * invertMouse), (float) ((double)deltaYaw * 0.15D), TASmodClient.tickratechanger.ticksPerSecond != 0);
 		}
 	}
 
@@ -174,11 +174,13 @@ public class MixinEntityRenderer implements SubtickDuck {
 	 */
 	private float redirectCam(float pitch, float yaw) {
 		Triple<Float, Float, Float> interpolated = TASmodClient.virtual.CAMERA_ANGLE.getInterpolatedState(Minecraft.getMinecraft().timer.renderPartialTicks, pitch, yaw, TASmodClient.controller.isPlayingback());
+		float pitch2 = interpolated.getLeft();
+		float yaw2 = interpolated.getMiddle();
 		// Update pitch
-		GlStateManager.rotate(interpolated.getLeft(), 1.0f, 0.0f, 0.0f);
+		GlStateManager.rotate(pitch2, 1.0f, 0.0f, 0.0f);
 		// Update roll
 		GlStateManager.rotate(interpolated.getRight(), 0.0f, 0.0f, 1.0f);
 		// Update yaw
-		return interpolated.getMiddle();
+		return yaw2;
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/networking/TASmodPackets.java
+++ b/src/main/java/com/minecrafttas/tasmod/networking/TASmodPackets.java
@@ -6,7 +6,7 @@ import com.minecrafttas.mctcommon.server.interfaces.PacketID;
 import com.minecrafttas.tasmod.commands.CommandFolder;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
-import com.minecrafttas.tasmod.playback.PlaybackSerialiser;
+import com.minecrafttas.tasmod.playback.tasfile.PlaybackSerialiser;
 import com.minecrafttas.tasmod.savestates.SavestateHandlerServer.PlayerHandler.MotionData;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerServer.TickratePauseState;
 

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -81,6 +81,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	 * The state of the controller when the state is paused
 	 */
 	private TASstate tempPause = TASstate.NONE;
+	
 	/**
 	 * The current index of the inputs
 	 */

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -12,7 +12,6 @@ import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_STATE;
 import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_TELEPORT;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -31,15 +30,18 @@ import com.minecrafttas.mctcommon.server.interfaces.ClientPacketHandler;
 import com.minecrafttas.mctcommon.server.interfaces.PacketID;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.TASmodClient;
+import com.minecrafttas.tasmod.events.EventClient.EventVirtualCameraAngleTick;
+import com.minecrafttas.tasmod.events.EventClient.EventVirtualKeyboardTick;
+import com.minecrafttas.tasmod.events.EventClient.EventVirtualMouseTick;
 import com.minecrafttas.tasmod.monitoring.DesyncMonitoring;
 import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
 import com.minecrafttas.tasmod.networking.TASmodPackets;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
 import com.minecrafttas.tasmod.util.Scheduler.Task;
+import com.minecrafttas.tasmod.virtual.VirtualCameraAngle;
 import com.minecrafttas.tasmod.virtual.VirtualInput;
 import com.minecrafttas.tasmod.virtual.VirtualKeyboard;
 import com.minecrafttas.tasmod.virtual.VirtualMouse;
-import com.minecrafttas.tasmod.virtual.VirtualCameraAngle;
 import com.mojang.realmsclient.gui.ChatFormatting;
 import com.mojang.realmsclient.util.Pair;
 
@@ -68,7 +70,7 @@ import net.minecraft.util.text.TextFormatting;
  * @author Scribble
  *
  */
-public class PlaybackControllerClient implements ClientPacketHandler {
+public class PlaybackControllerClient implements ClientPacketHandler, EventVirtualKeyboardTick, EventVirtualMouseTick, EventVirtualCameraAngleTick{
 
 	/**
 	 * The current state of the controller.
@@ -340,54 +342,21 @@ public class PlaybackControllerClient implements ClientPacketHandler {
 	// These act as an input and output, depending if a recording or a playback is
 	// running
 
-	/**
-	 * Adds or retrives a keyboard to the input container, depends on whether a
-	 * recording or a playback is running
-	 * 
-	 * @param keyboard Keyboard to add
-	 * @return Keyboard to retrieve
-	 */
-	public VirtualKeyboard addKeyboardToContainer(VirtualKeyboard keyboard) {
-		if (state == TASstate.RECORDING) {
-			this.keyboard = keyboard.clone();
-		} else if (state == TASstate.PLAYBACK) {
-			keyboard = this.keyboard.clone();
-		}
-		return keyboard;
+	@Override
+	public VirtualCameraAngle onVirtualCameraTick(VirtualCameraAngle vcamera) {
+		return null;
 	}
 
-	/**
-	 * Adds or retrives a mouse to the input container, depends on whether a
-	 * recording or a playback is running
-	 * 
-	 * @param mouse Mouse to add
-	 * @return Mouse to retrieve
-	 */
-	public VirtualMouse addMouseToContainer(VirtualMouse mouse) {
-		if (state == TASstate.RECORDING) {
-			this.mouse = mouse.clone();
-		} else if (state == TASstate.PLAYBACK) {
-			mouse = this.mouse.clone();
-		}
-		return mouse;
+	@Override
+	public VirtualMouse onVirtualMouseTick(VirtualMouse vmouse) {
+		return null;
 	}
 
-	/**
-	 * Adds or retrives the angle of the camera to the input container, depends on
-	 * whether a recording or a playback is running
-	 * 
-	 * @param subticks Subticks to add
-	 * @return Subticks to retrieve
-	 */
-	public VirtualCameraAngle addSubticksToContainer(VirtualCameraAngle subticks) {
-		if (state == TASstate.RECORDING) {
-			this.subticks = subticks.clone();
-		} else if (state == TASstate.PLAYBACK) {
-			subticks = this.subticks.clone();
-		}
-		return subticks;
+	@Override
+	public VirtualKeyboard onVirtualKeyboardTick(VirtualKeyboard vkeyboard) {
+		return null;
 	}
-
+	
 	/**
 	 * Updates the input container.<br>
 	 * <br>

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -80,7 +80,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	private TASstate state = TASstate.NONE;
 
 	/**
-	 * The state of the controller when the state is paused
+	 * The state of the controller when the {@link #state} is paused
 	 */
 	private TASstate tempPause = TASstate.NONE;
 	

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -30,6 +30,7 @@ import com.minecrafttas.mctcommon.server.interfaces.ClientPacketHandler;
 import com.minecrafttas.mctcommon.server.interfaces.PacketID;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.TASmodClient;
+import com.minecrafttas.tasmod.events.EventClient.EventClientTickPost;
 import com.minecrafttas.tasmod.events.EventClient.EventVirtualCameraAngleTick;
 import com.minecrafttas.tasmod.events.EventClient.EventVirtualKeyboardTick;
 import com.minecrafttas.tasmod.events.EventClient.EventVirtualMouseTick;
@@ -70,7 +71,7 @@ import net.minecraft.util.text.TextFormatting;
  * @author Scribble
  *
  */
-public class PlaybackControllerClient implements ClientPacketHandler, EventVirtualKeyboardTick, EventVirtualMouseTick, EventVirtualCameraAngleTick{
+public class PlaybackControllerClient implements ClientPacketHandler, EventVirtualKeyboardTick, EventVirtualMouseTick, EventVirtualCameraAngleTick, EventClientTickPost{
 
 	/**
 	 * The current state of the controller.
@@ -373,9 +374,10 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	 * {@linkplain #mouse} and {@linkplain #subticks} are retrieved and emulated as
 	 * the next inputs
 	 */
-	public void nextTick() {
+	@Override
+	public void onClientTickPost(Minecraft mc) {
 		/* Stop the playback while player is still loading */
-		EntityPlayerSP player = Minecraft.getMinecraft().player;
+		EntityPlayerSP player = mc.player;
 
 		if (player != null && player.addedToChunk) {
 			if (isPaused() && tempPause != TASstate.NONE) {

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -447,7 +447,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 		}
 
 		/* Stop condition */
-		if (index == inputs.size()) {
+		if (index == inputs.size() || inputs.isEmpty()) {
 			unpressContainer();
 			setTASState(TASstate.NONE);
 		}

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -9,7 +9,6 @@ import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_PLAYUNTI
 import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_RESTARTANDPLAY;
 import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_SAVE;
 import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_STATE;
-import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_TELEPORT;
 
 import java.io.File;
 import java.io.Serializable;
@@ -49,7 +48,6 @@ import com.minecrafttas.tasmod.virtual.VirtualCameraAngle;
 import com.minecrafttas.tasmod.virtual.VirtualInput;
 import com.minecrafttas.tasmod.virtual.VirtualKeyboard;
 import com.minecrafttas.tasmod.virtual.VirtualMouse;
-import com.mojang.realmsclient.gui.ChatFormatting;
 import com.mojang.realmsclient.util.Pair;
 
 import net.minecraft.client.Minecraft;
@@ -77,7 +75,7 @@ import net.minecraft.util.text.TextFormatting;
  * @author Scribble
  *
  */
-public class PlaybackControllerClient implements ClientPacketHandler, EventVirtualKeyboardTick, EventVirtualMouseTick, EventVirtualCameraAngleTick, EventClientTickPost{
+public class PlaybackControllerClient implements ClientPacketHandler, EventVirtualKeyboardTick, EventVirtualMouseTick, EventVirtualCameraAngleTick, EventClientTickPost {
 
 	/**
 	 * The current state of the controller.
@@ -88,7 +86,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	 * The state of the controller when the {@link #state} is paused
 	 */
 	private TASstate tempPause = TASstate.NONE;
-	
+
 	/**
 	 * The current index of the inputs
 	 */
@@ -117,22 +115,20 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	 * <p>
 	 * <code>Map(int playbackLine, List(Pair(String controlCommand, String[] arguments))</code>"
 	 */
-	private Map<Integer, List<Pair<String, String[]>>> controlBytes = new HashMap<Integer, List<Pair<String, String[]>>>();
+	private Map<Integer, List<Pair<String, String[]>>> controlBytes = new HashMap<Integer, List<Pair<String, String[]>>>(); // TODO Replace with TASFile extension
 
 	/**
 	 * The comments in the file, used to store them again later
 	 */
-	private Map<Integer, List<String>> comments = new HashMap<>();
+	private Map<Integer, List<String>> comments = new HashMap<>(); // TODO Replace with TASFile extension
 
-	public DesyncMonitoring desyncMonitor = new DesyncMonitoring(this);
+	public DesyncMonitoring desyncMonitor = new DesyncMonitoring(this); // TODO Replace with TASFile extension
 
-	// =====================================================================================================
-
-	private long startSeed = TASmod.ktrngHandler.getGlobalSeedClient();
+	private long startSeed = TASmod.ktrngHandler.getGlobalSeedClient(); // TODO Replace with Metadata extension
 
 	// =====================================================================================================
 
-	private Integer playUntil = null;
+	private Integer playUntil = null; // TODO Replace with event
 
 	/**
 	 * Sets the current {@link TASstate}
@@ -150,7 +146,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 			e.printStackTrace();
 		}
 	}
-	
+
 	/**
 	 * Starts or stops a recording/playback
 	 * 
@@ -170,7 +166,8 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	 */
 	public String setTASStateClient(TASstate stateIn, boolean verbose) {
 		EventListenerRegistry.fireEvent(EventControllerStateChange.class, stateIn, state);
-		ControlByteHandler.reset();	// FIXME Controlbytes are resetting when loading a world, due to "Paused" state being active during loading... Fix Paused state shenanigans?
+		ControlByteHandler.reset(); // FIXME Controlbytes are resetting when loading a world, due to "Paused" state
+									// being active during loading... Fix Paused state shenanigans?
 		if (state == stateIn) {
 			switch (stateIn) {
 				case PLAYBACK:
@@ -255,7 +252,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 		}
 		return "Something went wrong ._.";
 	}
-	
+
 	private void startRecording() {
 		LOGGER.debug(LoggerMarkers.Playback, "Starting recording");
 		if (this.inputs.isEmpty()) {
@@ -263,12 +260,12 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 			desyncMonitor.recordNull(index);
 		}
 	}
-	
+
 	private void stopRecording() {
 		LOGGER.debug(LoggerMarkers.Playback, "Stopping a recording");
 		TASmodClient.virtual.clear();
 	}
-	
+
 	private void startPlayback() {
 		LOGGER.debug(LoggerMarkers.Playback, "Starting playback");
 		Minecraft.getMinecraft().gameSettings.chatLinks = false; // #119
@@ -281,7 +278,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 		Minecraft.getMinecraft().gameSettings.chatLinks = true;
 		TASmodClient.virtual.clear();
 	}
-	
+
 	/**
 	 * Switches between the paused state and the state it was in before the pause
 	 * 
@@ -361,7 +358,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 		}
 		return vkeyboard.clone();
 	}
-	
+
 	@Override
 	public VirtualCameraAngle onVirtualCameraTick(VirtualCameraAngle vcamera) {
 		if (state == TASstate.RECORDING) {
@@ -371,7 +368,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 		}
 		return vcamera.clone();
 	}
-	
+
 	/**
 	 * Updates the input container.<br>
 	 * <br>
@@ -454,7 +451,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 			TickInputContainer tickcontainer = inputs.get(index); // Loads the new inputs from the container
 			this.keyboard = tickcontainer.getKeyboard().clone();
 			this.mouse = tickcontainer.getMouse().clone();
-			this.camera = tickcontainer.getSubticks().clone();
+			this.camera = tickcontainer.getCameraAngle().clone();
 			// check for control bytes
 			ControlByteHandler.readCotrolByte(controlBytes.get(index));
 		}
@@ -479,11 +476,11 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 		return inputs;
 	}
 
-	public Map<Integer, List<Pair<String, String[]>>> getControlBytes() {
+	public Map<Integer, List<Pair<String, String[]>>> getControlBytes() { // TODO Replace with TASFile extension
 		return controlBytes;
 	}
 
-	public Map<Integer, List<String>> getComments() {
+	public Map<Integer, List<String>> getComments() { // TODO Replace with TASFile extension
 		return comments;
 	}
 
@@ -494,7 +491,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 				TickInputContainer tickcontainer = inputs.get(index);
 				this.keyboard = tickcontainer.getKeyboard();
 				this.mouse = tickcontainer.getMouse();
-				this.camera = tickcontainer.getSubticks();
+				this.camera = tickcontainer.getCameraAngle();
 			}
 		} else {
 			throw new IndexOutOfBoundsException("Index is bigger than the container");
@@ -543,23 +540,11 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 		return out;
 	}
 
-	// =====================================================================================================
-	// Methods to set and retrieve author, title etc
-
-	public void fixTicks() {
+	public void fixTicks() { // TODO Remove and use Serializer to list ticks
 		for (int i = 0; i < inputs.size(); i++) {
 			inputs.get(i).setTick(i + 1);
 		}
 	}
-
-	public long getStartSeed() {
-		return startSeed;
-	}
-
-	public void setStartSeed(long startSeed) {
-		this.startSeed = startSeed;
-	}
-
 
 	// ==============================================================
 
@@ -573,8 +558,6 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	}
 
 	// ==============================================================
-
-
 
 	public void setPlayUntil(int until) {
 		this.playUntil = until;
@@ -627,7 +610,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 			return mouse;
 		}
 
-		public VirtualCameraAngle getSubticks() {
+		public VirtualCameraAngle getCameraAngle() {
 			return subticks;
 		}
 
@@ -675,11 +658,11 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 
 	public void setStateWhenOpened(TASstate state) {
 		TASmodClient.openMainMenuScheduler.add(() -> {
-			PlaybackControllerClient container = TASmodClient.controller;
-			if (state == TASstate.RECORDING) {
-				long seed = TASmod.ktrngHandler.getGlobalSeedClient();
-				container.setStartSeed(seed);
-			}
+//			PlaybackControllerClient container = TASmodClient.controller;	// Replace with event
+//			if (state == TASstate.RECORDING) {
+//				long seed = TASmod.ktrngHandler.getGlobalSeedClient();
+//				container.setStartSeed(seed);
+//			}
 			setTASState(state);
 		});
 	}
@@ -695,8 +678,9 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 				PLAYBACK_FULLRECORD, 
 				PLAYBACK_RESTARTANDPLAY, 
 				PLAYBACK_PLAYUNTIL, 
-				PLAYBACK_CLEAR_INPUTS,
-				PLAYBACK_STATE
+				PLAYBACK_CLEAR_INPUTS, 
+				PLAYBACK_STATE 
+				
 		};
 	}
 
@@ -795,31 +779,30 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 
 			case PLAYBACK_TELEPORT:
 				throw new WrongSideException(packet, Side.CLIENT);
-				
+
 			case PLAYBACK_STATE:
 				TASstate networkState = TASmodBufferBuilder.readTASState(buf);
 				boolean verbose = TASmodBufferBuilder.readBoolean(buf);
-				Task task = ()->{
+				Task task = () -> {
 					PlaybackControllerClient container = TASmodClient.controller;
 					if (networkState != container.getState()) {
-						
+
 						String message = container.setTASStateClient(networkState, verbose);
-						
+
 						if (!message.isEmpty()) {
-							if(Minecraft.getMinecraft().world != null)
+							if (Minecraft.getMinecraft().world != null)
 								Minecraft.getMinecraft().ingameGUI.getChatGUI().printChatMessage(new TextComponentString(message));
 							else
 								LOGGER.debug(LoggerMarkers.Playback, message);
-						} 
+						}
 					}
-					
+
 				};
-				
-				
-				if((networkState == TASstate.RECORDING || networkState == TASstate.PLAYBACK) && TASmodClient.tickratechanger.ticksPerSecond != 0) {
-					TASmodClient.tickSchedulerClient.add(task);	// Starts a recording in the next tick
+
+				if ((networkState == TASstate.RECORDING || networkState == TASstate.PLAYBACK) && TASmodClient.tickratechanger.ticksPerSecond != 0) {
+					TASmodClient.tickSchedulerClient.add(task); // Starts a recording in the next tick
 				} else {
-					TASmodClient.gameLoopSchedulerClient.add(task);	// Starts a recording in the next frame
+					TASmodClient.gameLoopSchedulerClient.add(task); // Starts a recording in the next frame
 				}
 				break;
 

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -345,18 +345,33 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	// running
 
 	@Override
-	public VirtualCameraAngle onVirtualCameraTick(VirtualCameraAngle vcamera) {
-		return null;
-	}
-
-	@Override
 	public VirtualMouse onVirtualMouseTick(VirtualMouse vmouse) {
-		return null;
+		if (state == TASstate.RECORDING) {
+			this.mouse.deepCopyFrom(vmouse);
+		} else if (state == TASstate.PLAYBACK) {
+			vmouse.deepCopyFrom(this.mouse);
+		}
+		return vmouse;
 	}
 
 	@Override
 	public VirtualKeyboard onVirtualKeyboardTick(VirtualKeyboard vkeyboard) {
-		return null;
+		if (state == TASstate.RECORDING) {
+			this.keyboard.deepCopyFrom(vkeyboard);
+		} else if (state == TASstate.PLAYBACK) {
+			vkeyboard.deepCopyFrom(this.keyboard);
+		}
+		return vkeyboard;
+	}
+	
+	@Override
+	public VirtualCameraAngle onVirtualCameraTick(VirtualCameraAngle vcamera) {
+		if (state == TASstate.RECORDING) {
+			this.subticks.deepCopyFrom(vcamera);
+		} else if (state == TASstate.PLAYBACK) {
+			vcamera.deepCopyFrom(vcamera);
+		}
+		return vcamera;
 	}
 	
 	/**

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -37,6 +37,7 @@ import com.minecrafttas.tasmod.events.EventClient.EventVirtualMouseTick;
 import com.minecrafttas.tasmod.monitoring.DesyncMonitoring;
 import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
 import com.minecrafttas.tasmod.networking.TASmodPackets;
+import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
 import com.minecrafttas.tasmod.util.Scheduler.Task;
 import com.minecrafttas.tasmod.virtual.VirtualCameraAngle;
@@ -66,7 +67,7 @@ import net.minecraft.util.text.TextFormatting;
  * Information about the author etc. get stored in the playback controller too
  * and will be printed out in chat when the player loads into a world <br>
  * Inputs are saved and loaded to/from file via the
- * {@linkplain PlaybackSerialiser}
+ * {@linkplain PlaybackSerialiser} TODO Update with new {@link PlaybackMetadata}
  * 
  * @author Scribble
  *
@@ -750,7 +751,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 			this.tick = tick;
 			this.keyboard = new VirtualKeyboard();
 			this.mouse = new VirtualMouse();
-//			this.subticks = new VirtualCameraAngle(0, 0);
+			this.subticks = new VirtualCameraAngle();
 		}
 
 		@Override

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -92,7 +92,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 
 	private VirtualMouse mouse = new VirtualMouse();
 
-	private VirtualCameraAngle subticks = new VirtualCameraAngle();
+	private VirtualCameraAngle camera = new VirtualCameraAngle();
 
 	public final File directory = new File(Minecraft.getMinecraft().mcDataDir.getAbsolutePath() + File.separator + "saves" + File.separator + "tasfiles");
 
@@ -383,9 +383,9 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	@Override
 	public VirtualCameraAngle onVirtualCameraTick(VirtualCameraAngle vcamera) {
 		if (state == TASstate.RECORDING) {
-			this.subticks.deepCopyFrom(vcamera);
+			this.camera.deepCopyFrom(vcamera);
 		} else if (state == TASstate.PLAYBACK) {
-			vcamera.deepCopyFrom(vcamera);
+			vcamera.deepCopyFrom(this.camera);
 		}
 		return vcamera.clone();
 	}
@@ -394,15 +394,15 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 	 * Updates the input container.<br>
 	 * <br>
 	 * During a recording this adds the {@linkplain #keyboard}, {@linkplain #mouse}
-	 * and {@linkplain #subticks} to {@linkplain #inputs} and increases the
+	 * and {@linkplain #camera} to {@linkplain #inputs} and increases the
 	 * {@linkplain #index}.<br>
 	 * <br>
 	 * During playback the opposite is happening, getting the inputs from
 	 * {@linkplain #inputs} and temporarily storing them in {@linkplain #keyboard},
-	 * {@linkplain #mouse} and {@linkplain #subticks}.<br>
+	 * {@linkplain #mouse} and {@linkplain #camera}.<br>
 	 * <br>
 	 * Then in {@linkplain VirtualInput}, {@linkplain #keyboard},
-	 * {@linkplain #mouse} and {@linkplain #subticks} are retrieved and emulated as
+	 * {@linkplain #mouse} and {@linkplain #camera} are retrieved and emulated as
 	 * the next inputs
 	 */
 	@Override
@@ -432,9 +432,9 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 			if (inputs.size() < index) {
 				LOGGER.warn("Index is {} inputs bigger than the container!", index - inputs.size());
 			}
-			inputs.add(new TickInputContainer(index, keyboard.clone(), mouse.clone(), subticks.clone()));
+			inputs.add(new TickInputContainer(index, keyboard.clone(), mouse.clone(), camera.clone()));
 		} else {
-			inputs.set(index, new TickInputContainer(index, keyboard.clone(), mouse.clone(), subticks.clone()));
+			inputs.set(index, new TickInputContainer(index, keyboard.clone(), mouse.clone(), camera.clone()));
 		}
 		desyncMonitor.recordMonitor(index); // Capturing monitor values
 	}
@@ -472,7 +472,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 			TickInputContainer tickcontainer = inputs.get(index); // Loads the new inputs from the container
 			this.keyboard = tickcontainer.getKeyboard().clone();
 			this.mouse = tickcontainer.getMouse().clone();
-			this.subticks = tickcontainer.getSubticks().clone();
+			this.camera = tickcontainer.getSubticks().clone();
 			// check for control bytes
 			ControlByteHandler.readCotrolByte(controlBytes.get(index));
 		}
@@ -512,7 +512,7 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventVirtu
 				TickInputContainer tickcontainer = inputs.get(index);
 				this.keyboard = tickcontainer.getKeyboard();
 				this.mouse = tickcontainer.getMouse();
-				this.subticks = tickcontainer.getSubticks();
+				this.camera = tickcontainer.getSubticks();
 			}
 		} else {
 			throw new IndexOutOfBoundsException("Index is bigger than the container");

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerServer.java
@@ -9,7 +9,6 @@ import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_PLAYUNTI
 import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_RESTARTANDPLAY;
 import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_SAVE;
 import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_STATE;
-import static com.minecrafttas.tasmod.networking.TASmodPackets.PLAYBACK_TELEPORT;
 import static com.minecrafttas.tasmod.util.LoggerMarkers.Playback;
 
 import java.nio.ByteBuffer;
@@ -23,8 +22,6 @@ import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
 import com.minecrafttas.tasmod.networking.TASmodPackets;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
-
-import net.minecraft.entity.player.EntityPlayerMP;
 
 /**
  * The playback controller on the server side.<br>
@@ -42,7 +39,6 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 		return new TASmodPackets[] 
 				{ 
 				PLAYBACK_STATE,
-				PLAYBACK_TELEPORT,
 				PLAYBACK_CLEAR_INPUTS,
 				PLAYBACK_FULLPLAY,
 				PLAYBACK_FULLRECORD,
@@ -63,22 +59,6 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 				TASstate networkState = TASmodBufferBuilder.readTASState(buf);
 				/* TODO Permissions */
 				setState(networkState);
-				break;
-
-			case PLAYBACK_TELEPORT:
-				double x = TASmodBufferBuilder.readDouble(buf);
-				double y = TASmodBufferBuilder.readDouble(buf);
-				double z = TASmodBufferBuilder.readDouble(buf);
-				float angleYaw = TASmodBufferBuilder.readFloat(buf);
-				float anglePitch = TASmodBufferBuilder.readFloat(buf);
-
-				EntityPlayerMP player = TASmod.getServerInstance().getPlayerList().getPlayerByUsername(username);
-				player.getServerWorld().addScheduledTask(() -> {
-					player.rotationPitch = anglePitch;
-					player.rotationYaw = angleYaw;
-
-					player.setPositionAndUpdate(x, y, z);
-				});
 				break;
 
 			case PLAYBACK_CLEAR_INPUTS:

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackMetadata.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackMetadata.java
@@ -1,0 +1,20 @@
+package com.minecrafttas.tasmod.playback;
+
+import java.util.LinkedHashMap;
+import java.util.Properties;
+
+/**
+ * Stores all tasfile specific metadata like author, rerecords and name.<br>
+ * <br>
+ * Each metadata is grouped by a group name.<br>
+ * Made to be easily modifiable so that you can add your own metadata.
+ */
+public class PlaybackMetadata {
+	LinkedHashMap<String, Properties> metadata;
+	
+	public PlaybackMetadata() {
+		this.metadata = new LinkedHashMap<>();
+	}
+	
+	
+}

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackSerialiser.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackSerialiser.java
@@ -7,7 +7,6 @@ import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TickInputContai
 import com.minecrafttas.tasmod.util.FileThread;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
 import com.minecrafttas.tasmod.virtual.VirtualCameraAngle;
-import com.minecrafttas.tasmod.virtual.VirtualKey;
 import com.minecrafttas.tasmod.virtual.VirtualKeyboard;
 import com.minecrafttas.tasmod.virtual.VirtualMouse;
 import com.mojang.realmsclient.util.Pair;

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackSerialiserBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackSerialiserBase.java
@@ -1,0 +1,40 @@
+package com.minecrafttas.tasmod.playback;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class PlaybackSerialiserBase {
+	
+	public PlaybackSerialiserBase(PlaybackControllerClient controller) {
+		if(controller == null) {
+			throw new NullPointerException("Parameter controller can't be null");
+		}
+		
+		
+	}
+	
+	public void onSave() {
+		
+	}
+	
+	public void onLoad() {
+		
+	}
+	
+	public List<String> serialize() {
+		List<String> out = new ArrayList<>();
+		return out;
+	}
+	
+	public void deserialize(List<String> in) {
+		
+	}
+	
+	public List<String> serializeMetadata(){
+		return null;
+	}
+	
+	public void deserializeMetadata(List<String> metadataString) {
+		
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
@@ -1,4 +1,4 @@
-package com.minecrafttas.tasmod.playback;
+package com.minecrafttas.tasmod.playback.metadata;
 
 import java.util.LinkedHashMap;
 import java.util.Properties;
@@ -16,5 +16,6 @@ public class PlaybackMetadata {
 		this.metadata = new LinkedHashMap<>();
 	}
 	
-	
+	public void setValue(String category, String key, String value) {
+	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
@@ -1,21 +1,80 @@
 package com.minecrafttas.tasmod.playback.metadata;
 
-import java.util.LinkedHashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * Stores all tasfile specific metadata like author, rerecords and name.<br>
+ * Stores a section of<br>
  * <br>
- * Each metadata is grouped by a group name.<br>
- * Made to be easily modifiable so that you can add your own metadata.
  */
 public class PlaybackMetadata {
-	LinkedHashMap<String, Properties> metadata;
-	
+	/**
+	 * Debug extension name
+	 */
+	String extensionName;
+	Properties metadata;
+
 	public PlaybackMetadata() {
-		this.metadata = new LinkedHashMap<>();
+		this.metadata = new Properties();
 	}
 	
-	public void setValue(String category, String key, String value) {
+	public PlaybackMetadata(String extensionName) {
+		this();
+		this.extensionName = extensionName; 
+	}
+
+	public void setValue(String key, String value) {
+		if(key.contains("=")) {
+			throw new IllegalArgumentException(String.format("%sKeyname %s can't contain =", extensionName!=null?extensionName+": ":"", key));
+		}
+	}
+
+	public String getValue(String key) {
+		return metadata.getProperty(key);
+	}
+
+	@Override
+	public String toString() {
+		String out = "";
+		for (Object keyObj : metadata.keySet()) {
+			String key = (String) keyObj;
+			String value = getValue(key);
+			out += (String.format("%s=%s\n", key, value));
+		}
+		return out;
+	}
+	
+	public List<String> toStringList(){
+		List<String> out= new ArrayList<>();
+		for (Object keyObj : metadata.keySet()) {
+			String key = (String) keyObj;
+			String value = getValue(key);
+			out.add(String.format("%s=%s\n", key, value));
+		}
+		return out;
+	}
+	
+	public static PlaybackMetadata fromStringList(String extensionName, List<String> list) {
+		return fromStringList(list);
+	}
+	
+	public static PlaybackMetadata fromStringList(List<String> list) { 
+		PlaybackMetadata out = new PlaybackMetadata();
+		
+        final Pattern pattern = Pattern.compile("(\\w+)=(.+)");
+		
+		for(String data: list) {
+			Matcher matcher = pattern.matcher(data);
+			if(matcher.find()) {
+				String key = matcher.group(1);
+				String value = matcher.group(2);
+				out.setValue(key, value);
+			}
+		}
+		
+		return out;
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
@@ -7,29 +7,30 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadataRegistry.PlaybackMetadataExtension;
+
 /**
  * Stores a section of<br>
  * <br>
  */
 public class PlaybackMetadata {
-	/**
-	 * Debug extension name
-	 */
 	private String extensionName;
 	private LinkedHashMap<String, String> metadata;
+	
+	private static String SEPERATOR = ":";
 
-	public PlaybackMetadata() {
+	public PlaybackMetadata(PlaybackMetadataExtension extension) {
+		this(extension.getExtensionName());
+	}
+
+	private PlaybackMetadata(String extensionName) {
+		this.extensionName = extensionName;
 		this.metadata = new LinkedHashMap<String, String>();
 	}
 
-	public PlaybackMetadata(String extensionName) {
-		this();
-		this.extensionName = extensionName;
-	}
-
 	public void setValue(String key, String value) {
-		if (key.contains("=")) {
-			throw new IllegalArgumentException(String.format("%sKeyname %s can't contain =", extensionName != null ? extensionName + ": " : "", key));
+		if (key.contains(SEPERATOR)) {
+			throw new IllegalArgumentException(String.format("%sKeyname %s can't contain %s", extensionName != null ? extensionName + ": " : "", key, SEPERATOR));
 		}
 		metadata.put(key, value);
 	}
@@ -43,7 +44,7 @@ public class PlaybackMetadata {
 		String out = "";
 		for (String key : metadata.keySet()) {
 			String value = getValue(key);
-			out += (String.format("%s=%s\n", key, value));
+			out += (String.format("%s%s%s\n", key, SEPERATOR, value));
 		}
 		return out;
 	}
@@ -53,7 +54,7 @@ public class PlaybackMetadata {
 		for (Object keyObj : metadata.keySet()) {
 			String key = (String) keyObj;
 			String value = getValue(key);
-			out.add(String.format("%s=%s\n", key, value));
+			out.add(String.format("%s%s%s\n", key, SEPERATOR, value));
 		}
 		return out;
 	}
@@ -76,13 +77,9 @@ public class PlaybackMetadata {
 	}
 
 	public static PlaybackMetadata fromStringList(String extensionName, List<String> list) {
-		return fromStringList(list);
-	}
+		PlaybackMetadata out = new PlaybackMetadata(extensionName);
 
-	public static PlaybackMetadata fromStringList(List<String> list) {
-		PlaybackMetadata out = new PlaybackMetadata();
-
-		final Pattern pattern = Pattern.compile("(\\w+)=(.+)");
+		final Pattern pattern = Pattern.compile("(\\w+)\\"+SEPERATOR+"(.+)");
 
 		for (String data : list) {
 			Matcher matcher = pattern.matcher(data);

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
@@ -14,22 +14,23 @@ public class PlaybackMetadata {
 	/**
 	 * Debug extension name
 	 */
-	String extensionName;
-	Properties metadata;
+	private String extensionName;
+	private Properties metadata;
 
 	public PlaybackMetadata() {
 		this.metadata = new Properties();
 	}
-	
+
 	public PlaybackMetadata(String extensionName) {
 		this();
-		this.extensionName = extensionName; 
+		this.extensionName = extensionName;
 	}
 
 	public void setValue(String key, String value) {
-		if(key.contains("=")) {
-			throw new IllegalArgumentException(String.format("%sKeyname %s can't contain =", extensionName!=null?extensionName+": ":"", key));
+		if (key.contains("=")) {
+			throw new IllegalArgumentException(String.format("%sKeyname %s can't contain =", extensionName != null ? extensionName + ": " : "", key));
 		}
+		metadata.setProperty(key, value);
 	}
 
 	public String getValue(String key) {
@@ -46,9 +47,9 @@ public class PlaybackMetadata {
 		}
 		return out;
 	}
-	
-	public List<String> toStringList(){
-		List<String> out= new ArrayList<>();
+
+	public List<String> toStringList() {
+		List<String> out = new ArrayList<>();
 		for (Object keyObj : metadata.keySet()) {
 			String key = (String) keyObj;
 			String value = getValue(key);
@@ -57,24 +58,32 @@ public class PlaybackMetadata {
 		return out;
 	}
 	
+	public String getExtensionName() {
+		return extensionName;
+	}
+	
+	public Properties getMetadata() {
+		return metadata;
+	}
+	
 	public static PlaybackMetadata fromStringList(String extensionName, List<String> list) {
 		return fromStringList(list);
 	}
-	
-	public static PlaybackMetadata fromStringList(List<String> list) { 
+
+	public static PlaybackMetadata fromStringList(List<String> list) {
 		PlaybackMetadata out = new PlaybackMetadata();
-		
-        final Pattern pattern = Pattern.compile("(\\w+)=(.+)");
-		
-		for(String data: list) {
+
+		final Pattern pattern = Pattern.compile("(\\w+)=(.+)");
+
+		for (String data : list) {
 			Matcher matcher = pattern.matcher(data);
-			if(matcher.find()) {
+			if (matcher.find()) {
 				String key = matcher.group(1);
 				String value = matcher.group(2);
 				out.setValue(key, value);
 			}
 		}
-		
+
 		return out;
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
@@ -1,13 +1,9 @@
 package com.minecrafttas.tasmod.playback.metadata;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,7 +47,7 @@ public class PlaybackMetadata {
 		}
 		return out;
 	}
-	
+
 	public List<String> toStringList() {
 		List<String> out = new ArrayList<>();
 		for (Object keyObj : metadata.keySet()) {
@@ -61,24 +57,24 @@ public class PlaybackMetadata {
 		}
 		return out;
 	}
-	
+
 	public String getExtensionName() {
 		return extensionName;
 	}
-	
+
 	public HashMap<String, String> getMetadata() {
 		return metadata;
 	}
-	
+
 	@Override
 	public boolean equals(Object obj) {
-		if(obj instanceof PlaybackMetadata) {
+		if (obj instanceof PlaybackMetadata) {
 			PlaybackMetadata other = (PlaybackMetadata) obj;
 			return other.metadata.equals(metadata) && other.extensionName.equals(extensionName);
 		}
 		return super.equals(obj);
 	}
-	
+
 	public static PlaybackMetadata fromStringList(String extensionName, List<String> list) {
 		return fromStringList(list);
 	}

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadata.java
@@ -1,8 +1,13 @@
 package com.minecrafttas.tasmod.playback.metadata;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -15,10 +20,10 @@ public class PlaybackMetadata {
 	 * Debug extension name
 	 */
 	private String extensionName;
-	private Properties metadata;
+	private LinkedHashMap<String, String> metadata;
 
 	public PlaybackMetadata() {
-		this.metadata = new Properties();
+		this.metadata = new LinkedHashMap<String, String>();
 	}
 
 	public PlaybackMetadata(String extensionName) {
@@ -30,24 +35,23 @@ public class PlaybackMetadata {
 		if (key.contains("=")) {
 			throw new IllegalArgumentException(String.format("%sKeyname %s can't contain =", extensionName != null ? extensionName + ": " : "", key));
 		}
-		metadata.setProperty(key, value);
+		metadata.put(key, value);
 	}
 
 	public String getValue(String key) {
-		return metadata.getProperty(key);
+		return metadata.get(key);
 	}
 
 	@Override
 	public String toString() {
 		String out = "";
-		for (Object keyObj : metadata.keySet()) {
-			String key = (String) keyObj;
+		for (String key : metadata.keySet()) {
 			String value = getValue(key);
 			out += (String.format("%s=%s\n", key, value));
 		}
 		return out;
 	}
-
+	
 	public List<String> toStringList() {
 		List<String> out = new ArrayList<>();
 		for (Object keyObj : metadata.keySet()) {
@@ -62,8 +66,17 @@ public class PlaybackMetadata {
 		return extensionName;
 	}
 	
-	public Properties getMetadata() {
+	public HashMap<String, String> getMetadata() {
 		return metadata;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if(obj instanceof PlaybackMetadata) {
+			PlaybackMetadata other = (PlaybackMetadata) obj;
+			return other.metadata.equals(metadata) && other.extensionName.equals(extensionName);
+		}
+		return super.equals(obj);
 	}
 	
 	public static PlaybackMetadata fromStringList(String extensionName, List<String> list) {

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
@@ -1,13 +1,26 @@
 package com.minecrafttas.tasmod.playback.metadata;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 
 import com.minecrafttas.mctcommon.MCTCommon;
 
+/**
+ * Registry for registering custom metadata that is stored in the TASFile.<br>
+ * <br>
+ * The default metadata includes general information such as author name, savestate/rerecord count and category.<br>
+ * <br>
+ * Any custom class has to extend PlaybackMetadataExtension
+ * 
+ */
 public class PlaybackMetadataRegistry {
 
 	private static final ArrayList<PlaybackMetadataExtension> METADATA_EXTENSION = new ArrayList<>();
 
+	/**
+	 * Registers a new class as a metadata extension
+	 * @param extension
+	 */
 	public static void register(PlaybackMetadataExtension extension) {
 		if(extension==null) {
 			throw new NullPointerException("Tried to register a playback extension with value null");
@@ -36,12 +49,15 @@ public class PlaybackMetadataRegistry {
 		}
 	}
 	
-	public static PlaybackMetadata handleOnLoad() {
-		return null; //TODO implement
+	public static void handleOnCreate() {
+		
 	}
 	
-	public static void handleOnStore(PlaybackMetadata metadata) {
-		//TODO
+	public static LinkedHashMap<String, PlaybackMetadata> handleOnLoad() {
+		return null;
+	}
+	
+	public static void handleOnStore(LinkedHashMap<String, PlaybackMetadata> metadata) {
 	}
 	
 	private static boolean containsClass(PlaybackMetadataExtension newExtension) {
@@ -54,6 +70,11 @@ public class PlaybackMetadataRegistry {
 	}
 
 	public static interface PlaybackMetadataExtension {
+		
+		public String getExtensionName();
+		
+		public void onCreate();
+		
 		public PlaybackMetadata onStore();
 
 		public void onLoad(PlaybackMetadata metadata);

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
@@ -1,0 +1,61 @@
+package com.minecrafttas.tasmod.playback.metadata;
+
+import java.util.ArrayList;
+
+import com.minecrafttas.mctcommon.MCTCommon;
+
+public class PlaybackMetadataRegistry {
+
+	private static final ArrayList<PlaybackMetadataExtension> METADATA_EXTENSION = new ArrayList<>();
+
+	public static void register(PlaybackMetadataExtension extension) {
+		if(extension==null) {
+			throw new NullPointerException("Tried to register a playback extension with value null");
+		}
+		
+		if(containsClass(extension)) {
+			MCTCommon.LOGGER.warn("Trying to register the playback extension {}, but another instance of this class is already registered!", extension.getClass().getName());
+			return;
+		}
+		
+		if (!METADATA_EXTENSION.contains(extension)) {
+			METADATA_EXTENSION.add(extension);
+		} else {
+			MCTCommon.LOGGER.warn("Trying to register the playback extension {}, but it is already registered!", extension.getClass().getName());
+		}
+	}
+
+	public static void unregister(PlaybackMetadataExtension extension) {
+		if(extension==null) {
+			throw new NullPointerException("Tried to unregister an extension with value null");
+		}
+		if (METADATA_EXTENSION.contains(extension)) {
+			METADATA_EXTENSION.remove(extension);
+		} else {
+			MCTCommon.LOGGER.warn("Trying to unregister the playback extension {}, but it was not registered!", extension.getClass().getName());
+		}
+	}
+	
+	public static PlaybackMetadata handleOnLoad() {
+		return null; //TODO implement
+	}
+	
+	public static void handleOnStore(PlaybackMetadata metadata) {
+		//TODO
+	}
+	
+	private static boolean containsClass(PlaybackMetadataExtension newExtension) {
+		for(PlaybackMetadataExtension extension : METADATA_EXTENSION) {
+			if(extension.getClass().equals(newExtension.getClass())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public static interface PlaybackMetadataExtension {
+		public PlaybackMetadata onStore();
+
+		public void onLoad(PlaybackMetadata metadata);
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
@@ -8,7 +8,8 @@ import com.minecrafttas.mctcommon.MCTCommon;
 /**
  * Registry for registering custom metadata that is stored in the TASFile.<br>
  * <br>
- * The default metadata includes general information such as author name, savestate/rerecord count and category.<br>
+ * The default metadata includes general information such as author name,
+ * savestate/rerecord count and category.<br>
  * <br>
  * Any custom class has to extend PlaybackMetadataExtension
  * 
@@ -19,18 +20,19 @@ public class PlaybackMetadataRegistry {
 
 	/**
 	 * Registers a new class as a metadata extension
+	 * 
 	 * @param extension
 	 */
 	public static void register(PlaybackMetadataExtension extension) {
-		if(extension==null) {
+		if (extension == null) {
 			throw new NullPointerException("Tried to register a playback extension with value null");
 		}
-		
-		if(containsClass(extension)) {
+
+		if (containsClass(extension)) {
 			MCTCommon.LOGGER.warn("Trying to register the playback extension {}, but another instance of this class is already registered!", extension.getClass().getName());
 			return;
 		}
-		
+
 		if (!METADATA_EXTENSION.contains(extension)) {
 			METADATA_EXTENSION.add(extension);
 		} else {
@@ -39,7 +41,7 @@ public class PlaybackMetadataRegistry {
 	}
 
 	public static void unregister(PlaybackMetadataExtension extension) {
-		if(extension==null) {
+		if (extension == null) {
 			throw new NullPointerException("Tried to unregister an extension with value null");
 		}
 		if (METADATA_EXTENSION.contains(extension)) {
@@ -48,21 +50,21 @@ public class PlaybackMetadataRegistry {
 			MCTCommon.LOGGER.warn("Trying to unregister the playback extension {}, but it was not registered!", extension.getClass().getName());
 		}
 	}
-	
+
 	public static void handleOnCreate() {
-		
+
 	}
-	
+
 	public static LinkedHashMap<String, PlaybackMetadata> handleOnLoad() {
 		return null;
 	}
-	
+
 	public static void handleOnStore(LinkedHashMap<String, PlaybackMetadata> metadata) {
 	}
-	
+
 	private static boolean containsClass(PlaybackMetadataExtension newExtension) {
-		for(PlaybackMetadataExtension extension : METADATA_EXTENSION) {
-			if(extension.getClass().equals(newExtension.getClass())) {
+		for (PlaybackMetadataExtension extension : METADATA_EXTENSION) {
+			if (extension.getClass().equals(newExtension.getClass())) {
 				return true;
 			}
 		}
@@ -70,11 +72,11 @@ public class PlaybackMetadataRegistry {
 	}
 
 	public static interface PlaybackMetadataExtension {
-		
+
 		public String getExtensionName();
-		
+
 		public void onCreate();
-		
+
 		public PlaybackMetadata onStore();
 
 		public void onLoad(PlaybackMetadata metadata);

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
@@ -2,8 +2,10 @@ package com.minecrafttas.tasmod.playback.metadata;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
-import com.minecrafttas.mctcommon.MCTCommon;
+import com.minecrafttas.tasmod.TASmod;
 
 /**
  * Registry for registering custom metadata that is stored in the TASFile.<br>
@@ -16,7 +18,7 @@ import com.minecrafttas.mctcommon.MCTCommon;
  */
 public class PlaybackMetadataRegistry {
 
-	private static final ArrayList<PlaybackMetadataExtension> METADATA_EXTENSION = new ArrayList<>();
+	private static final Map<String, PlaybackMetadataExtension> METADATA_EXTENSION = new LinkedHashMap<>();
 
 	/**
 	 * Registers a new class as a metadata extension
@@ -29,25 +31,26 @@ public class PlaybackMetadataRegistry {
 		}
 
 		if (containsClass(extension)) {
-			MCTCommon.LOGGER.warn("Trying to register the playback extension {}, but another instance of this class is already registered!", extension.getClass().getName());
+			TASmod.LOGGER.warn("Trying to register the playback extension {}, but another instance of this class is already registered!", extension.getClass().getName());
 			return;
 		}
 
-		if (!METADATA_EXTENSION.contains(extension)) {
-			METADATA_EXTENSION.add(extension);
-		} else {
-			MCTCommon.LOGGER.warn("Trying to register the playback extension {}, but it is already registered!", extension.getClass().getName());
+		if(METADATA_EXTENSION.containsKey(extension.getExtensionName())) {
+			TASmod.LOGGER.warn("Trying to register the playback extension {}, but an extension with the same name is already registered!", extension.getExtensionName());
+			return;
 		}
+		
+		METADATA_EXTENSION.put(extension.getExtensionName(), extension);
 	}
 
 	public static void unregister(PlaybackMetadataExtension extension) {
 		if (extension == null) {
 			throw new NullPointerException("Tried to unregister an extension with value null");
 		}
-		if (METADATA_EXTENSION.contains(extension)) {
-			METADATA_EXTENSION.remove(extension);
+		if (METADATA_EXTENSION.containsKey(extension.getExtensionName())) {
+			METADATA_EXTENSION.remove(extension.getExtensionName());
 		} else {
-			MCTCommon.LOGGER.warn("Trying to unregister the playback extension {}, but it was not registered!", extension.getClass().getName());
+			TASmod.LOGGER.warn("Trying to unregister the playback extension {}, but it was not registered!", extension.getClass().getName());
 		}
 	}
 
@@ -55,15 +58,28 @@ public class PlaybackMetadataRegistry {
 
 	}
 
-	public static LinkedHashMap<String, PlaybackMetadata> handleOnLoad() {
-		return null;
+	public static List<PlaybackMetadata> handleOnStore() {
+		List<PlaybackMetadata> metadataList = new ArrayList<>();
+		for(PlaybackMetadataExtension extension : METADATA_EXTENSION.values()) {
+			metadataList.add(extension.onStore());
+		}
+		return metadataList;
 	}
 
-	public static void handleOnStore(LinkedHashMap<String, PlaybackMetadata> metadata) {
+	public static void handleOnLoad(List<PlaybackMetadata> meta) {
+		for(PlaybackMetadata metadata : meta) {
+			if(METADATA_EXTENSION.containsKey(metadata.getExtensionName())) {
+				PlaybackMetadataExtension extension = METADATA_EXTENSION.get(metadata.getExtensionName());
+				
+				extension.onLoad(metadata);
+			} else {
+				TASmod.LOGGER.warn("The metadata extension {} was not found while loading the TASFile. Things might not be correctly loaded!", metadata.getExtensionName());
+			}
+		}
 	}
 
 	private static boolean containsClass(PlaybackMetadataExtension newExtension) {
-		for (PlaybackMetadataExtension extension : METADATA_EXTENSION) {
+		for (PlaybackMetadataExtension extension : METADATA_EXTENSION.values()) {
 			if (extension.getClass().equals(newExtension.getClass())) {
 				return true;
 			}

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
@@ -88,13 +88,35 @@ public class PlaybackMetadataRegistry {
 	}
 
 	public static interface PlaybackMetadataExtension {
-
+		
+		/**
+		 * The name of this playback metadata extension.<br>
+		 * The name is printed in the playback file and declares this "section".<br>
+		 * It is also used in the {@link PlaybackMetadata} itself to link the metadata to the extension.<br>
+		 * @return The name of this playback metadata extension.
+		 */
 		public String getExtensionName();
 
+		/**
+		 * Currently unused.<br>
+		 * Maybe in the future, TASes have to be created with /create, then you can interactively set the values...<br>
+		 */
 		public void onCreate();
 
+		/**
+		 * Runs, when the TASfile is being stored to a file.<br>
+		 * Create a new {@link PlaybackMetadata} with <code>PlaybackMetadata metadata = new PlaybackMetadata(this);</code>.<br>
+		 * This will ensure, that the metadata is linked to this extension by using the {@link PlaybackMetadataExtension#getExtensionName()}.<br>
+		 * 
+		 * @return The {@link PlaybackMetadata} to be saved in the TASfile
+		 */
 		public PlaybackMetadata onStore();
 
+		/**
+		 * Runs when the TASfile is being loaded from a file<br>
+		 * 
+		 * @param metadata The metadata for this extension to read from
+		 */
 		public void onLoad(PlaybackMetadata metadata);
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
@@ -77,6 +77,12 @@ public class PlaybackMetadataRegistry {
 			}
 		}
 	}
+	
+	public static void handleOnClear() {
+		METADATA_EXTENSION.forEach((key, extension) ->{
+			extension.onClear();
+		});
+	}
 
 	private static boolean containsClass(PlaybackMetadataExtension newExtension) {
 		for (PlaybackMetadataExtension extension : METADATA_EXTENSION.values()) {
@@ -118,5 +124,10 @@ public class PlaybackMetadataRegistry {
 		 * @param metadata The metadata for this extension to read from
 		 */
 		public void onLoad(PlaybackMetadata metadata);
+		
+		/**
+		 * Runs when the PlaybackController is cleared
+		 */
+		public void onClear();
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/integrated/CreditsMetadataExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/integrated/CreditsMetadataExtension.java
@@ -1,0 +1,103 @@
+package com.minecrafttas.tasmod.playback.metadata.integrated;
+
+import static com.minecrafttas.tasmod.TASmod.LOGGER;
+
+import com.minecrafttas.tasmod.events.EventPlaybackClient.EventControllerStateChange;
+import com.minecrafttas.tasmod.events.EventPlaybackClient.EventPlaybackJoinedWorld;
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
+import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
+import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadataRegistry.PlaybackMetadataExtension;
+import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackLoadException;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
+import com.mojang.realmsclient.gui.ChatFormatting;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.text.TextComponentString;
+
+public class CreditsMetadataExtension implements PlaybackMetadataExtension, EventPlaybackJoinedWorld, EventControllerStateChange {
+
+	/**
+	 * The title/category of the TAS (e.g. KillSquid - Any% Glitched)
+	 */
+	private String title = "Insert TAS category here";
+	/**
+	 * The author(s) of the TAS (e.g. Scribble, Pancake)
+	 */
+	private String authors = "Insert author here";
+	/**
+	 * How long the TAS is going to take (e.g. 00:01.0 or 20ticks)
+	 */
+	private String playtime = "00:00.0";
+	/**
+	 * How often a savestate was loaded as a measurement of effort (e.g. 200)
+	 */
+	private int rerecords = 0;
+	
+	/**
+	 * If the credits where already printed in this instance
+	 */
+	private boolean creditsPrinted = false;
+
+	@Override
+	public String getExtensionName() {
+		return "Credits";
+	}
+
+	@Override
+	public void onCreate() {
+		// Unused atm
+	}
+
+	@Override
+	public PlaybackMetadata onStore() {
+		PlaybackMetadata metadata = new PlaybackMetadata(this);
+		metadata.setValue("Title", title);
+		metadata.setValue("Author", authors);
+		metadata.setValue("Playing Time", playtime);
+		metadata.setValue("Rerecords", Integer.toString(rerecords));
+		return metadata;
+	}
+
+	@Override
+	public void onLoad(PlaybackMetadata metadata) {
+		title = metadata.getValue("Title");
+		authors = metadata.getValue("Author");
+		playtime = metadata.getValue("Playing Time");
+		try {
+			rerecords = Integer.parseInt(metadata.getValue("Rerecords"));
+		} catch (NumberFormatException e) {
+			rerecords = 0;
+			throw new PlaybackLoadException(e);
+		}
+	}
+
+	@Override
+	public void onPlaybackJoinedWorld(TASstate state) {
+		LOGGER.trace(LoggerMarkers.Playback, "Printing credits");
+		if (state == TASstate.PLAYBACK && !creditsPrinted) {
+			creditsPrinted = true;
+			printMessage(title, ChatFormatting.GOLD);
+			printMessage("", null);
+			printMessage("by " + authors, ChatFormatting.AQUA);
+			printMessage("", null);
+			printMessage("in " + playtime, null);
+			printMessage("", null);
+			printMessage("Rerecords: " + rerecords, null);
+		}
+	}
+
+	private void printMessage(String msg, ChatFormatting format) {
+		String formatString = "";
+		if (format != null)
+			formatString = format.toString();
+
+		Minecraft.getMinecraft().ingameGUI.getChatGUI().printChatMessage(new TextComponentString(formatString + msg));
+	}
+
+	@Override
+	public void onControllerStateChange(TASstate newstate, TASstate oldstate) {
+		if(newstate == TASstate.PLAYBACK) {		// Reset creditsPrinted when a new playback is started
+			creditsPrinted = false;
+		}
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/integrated/CreditsMetadataExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/integrated/CreditsMetadataExtension.java
@@ -72,6 +72,15 @@ public class CreditsMetadataExtension implements PlaybackMetadataExtension, Even
 	}
 
 	@Override
+	public void onClear() {
+		title = "Insert TAS category here";
+		authors = "Insert author here";
+		playtime = "00:00.0";
+		rerecords = 0;
+		creditsPrinted = false;
+	}
+	
+	@Override
 	public void onPlaybackJoinedWorld(TASstate state) {
 		LOGGER.trace(LoggerMarkers.Playback, "Printing credits");
 		if (state == TASstate.PLAYBACK && !creditsPrinted) {

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/integrated/CreditsMetadataExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/integrated/CreditsMetadataExtension.java
@@ -9,11 +9,17 @@ import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadataRegistry.PlaybackMetadataExtension;
 import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackLoadException;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
-import com.mojang.realmsclient.gui.ChatFormatting;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextFormatting;
 
+/**
+ * Adds credits to the playback metadata<br>
+ * <br>
+ * Credits can be changed in the file and will be printed in chat, when the
+ * player joins a world after /fullplay
+ */
 public class CreditsMetadataExtension implements PlaybackMetadataExtension, EventPlaybackJoinedWorld, EventControllerStateChange {
 
 	/**
@@ -32,7 +38,7 @@ public class CreditsMetadataExtension implements PlaybackMetadataExtension, Even
 	 * How often a savestate was loaded as a measurement of effort (e.g. 200)
 	 */
 	private int rerecords = 0;
-	
+
 	/**
 	 * If the credits where already printed in this instance
 	 */
@@ -79,15 +85,15 @@ public class CreditsMetadataExtension implements PlaybackMetadataExtension, Even
 		rerecords = 0;
 		creditsPrinted = false;
 	}
-	
+
 	@Override
 	public void onPlaybackJoinedWorld(TASstate state) {
 		LOGGER.trace(LoggerMarkers.Playback, "Printing credits");
 		if (state == TASstate.PLAYBACK && !creditsPrinted) {
 			creditsPrinted = true;
-			printMessage(title, ChatFormatting.GOLD);
+			printMessage(title, TextFormatting.GOLD);
 			printMessage("", null);
-			printMessage("by " + authors, ChatFormatting.AQUA);
+			printMessage("by " + authors, TextFormatting.AQUA);
 			printMessage("", null);
 			printMessage("in " + playtime, null);
 			printMessage("", null);
@@ -95,7 +101,7 @@ public class CreditsMetadataExtension implements PlaybackMetadataExtension, Even
 		}
 	}
 
-	private void printMessage(String msg, ChatFormatting format) {
+	private void printMessage(String msg, TextFormatting format) {
 		String formatString = "";
 		if (format != null)
 			formatString = format.toString();
@@ -105,7 +111,7 @@ public class CreditsMetadataExtension implements PlaybackMetadataExtension, Even
 
 	@Override
 	public void onControllerStateChange(TASstate newstate, TASstate oldstate) {
-		if(newstate == TASstate.PLAYBACK) {		// Reset creditsPrinted when a new playback is started
+		if (newstate == TASstate.PLAYBACK) { // Reset creditsPrinted when a new playback is started
 			creditsPrinted = false;
 		}
 	}

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/integrated/StartpositionMetadataExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/integrated/StartpositionMetadataExtension.java
@@ -1,0 +1,139 @@
+package com.minecrafttas.tasmod.playback.metadata.integrated;
+
+import static com.minecrafttas.tasmod.TASmod.LOGGER;
+
+import java.nio.ByteBuffer;
+
+import com.minecrafttas.mctcommon.server.exception.PacketNotImplementedException;
+import com.minecrafttas.mctcommon.server.exception.WrongSideException;
+import com.minecrafttas.mctcommon.server.interfaces.PacketID;
+import com.minecrafttas.mctcommon.server.interfaces.ServerPacketHandler;
+import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.TASmodClient;
+import com.minecrafttas.tasmod.events.EventPlaybackClient.EventControllerStateChange;
+import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
+import com.minecrafttas.tasmod.networking.TASmodPackets;
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
+import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
+import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadataRegistry.PlaybackMetadataExtension;
+import com.minecrafttas.tasmod.util.LoggerMarkers;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+public class StartpositionMetadataExtension implements PlaybackMetadataExtension, EventControllerStateChange, ServerPacketHandler {
+
+	StartPosition startPosition = null;
+
+	public static class StartPosition{
+		
+		final double x;
+		final double y;
+		final double z;
+		final float pitch;
+		final float yaw;
+		
+		public StartPosition(double x, double y, double z, float pitch, float yaw) {
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.pitch = pitch;
+			this.yaw = yaw;
+		}
+		
+		@Override
+		public String toString() {
+			return String.format("%e,%e,%e,%e,%e", x, y, z, pitch, yaw);
+		}
+	}
+	
+	@Override
+	public String getExtensionName() {
+		return "Start Position";
+	}
+
+	@Override
+	public void onCreate() {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public PlaybackMetadata onStore() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void onLoad(PlaybackMetadata metadata) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void onClear() {
+		startPosition = null;
+	}
+	
+	@Override
+	public void onControllerStateChange(TASstate newstate, TASstate oldstate) {
+		Minecraft mc = Minecraft.getMinecraft();
+		
+		if(mc.player!=null) {
+			EntityPlayerSP player = mc.player;
+			
+			if(oldstate == TASstate.NONE && newstate == TASstate.RECORDING && startPosition == null) {	// If a recording is started, the player is in a world and startposition is uninitialized
+				LOGGER.debug(LoggerMarkers.Playback, "Setting start location");
+				startPosition = new StartPosition(player.posX, player.posY, player.posZ, player.rotationPitch, player.rotationYaw);
+			}
+			
+			if(oldstate == TASstate.NONE && newstate == TASstate.PLAYBACK && startPosition != null) {
+				LOGGER.debug(LoggerMarkers.Playback, "Teleporting the player to the start location");
+				TASmodBufferBuilder packetBuilder = new TASmodBufferBuilder(TASmodPackets.PLAYBACK_TELEPORT);
+				
+				packetBuilder
+				.writeDouble(startPosition.x)
+				.writeDouble(startPosition.y)
+				.writeDouble(startPosition.z)
+				.writeFloat(startPosition.pitch)
+				.writeFloat(startPosition.yaw);
+				
+				try {
+					TASmodClient.client.send(packetBuilder);
+				} catch (Exception e) {
+					LOGGER.error("Unable to teleport player to start location", e);
+				}
+			}
+		}
+		
+	}
+
+	@Override
+	public PacketID[] getAcceptedPacketIDs() {
+		return new PacketID[] {
+				TASmodPackets.PLAYBACK_TELEPORT
+		};
+	}
+
+	@Override
+	public void onServerPacket(PacketID id, ByteBuffer buf, String username) throws PacketNotImplementedException, WrongSideException, Exception {
+		TASmodPackets packet = (TASmodPackets) id;
+
+		if (packet == TASmodPackets.PLAYBACK_TELEPORT) {
+			double x = TASmodBufferBuilder.readDouble(buf);
+			double y = TASmodBufferBuilder.readDouble(buf);
+			double z = TASmodBufferBuilder.readDouble(buf);
+			float angleYaw = TASmodBufferBuilder.readFloat(buf);
+			float anglePitch = TASmodBufferBuilder.readFloat(buf);
+
+			EntityPlayerMP player = TASmod.getServerInstance().getPlayerList().getPlayerByUsername(username);
+			player.getServerWorld().addScheduledTask(() -> {
+				player.rotationPitch = anglePitch;
+				player.rotationYaw = angleYaw;
+
+				player.setPositionAndUpdate(x, y, z);
+			});
+		}
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/playback/tasfile/PlaybackSerialiser.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/tasfile/PlaybackSerialiser.java
@@ -288,7 +288,7 @@ public class PlaybackSerialiser {
 //		controller.setPlaytime(playtime);
 //		controller.setRerecords(rerecords);
 //		controller.setStartLocation(startLocation);
-		controller.setStartSeed(startSeed);
+//		controller.setStartSeed(startSeed);
 		if(!monitorLines.isEmpty()) {
 			controller.desyncMonitor = new DesyncMonitoring(controller, monitorLines);
 		}

--- a/src/main/java/com/minecrafttas/tasmod/playback/tasfile/PlaybackSerialiser.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/tasfile/PlaybackSerialiser.java
@@ -1,8 +1,10 @@
-package com.minecrafttas.tasmod.playback;
+package com.minecrafttas.tasmod.playback.tasfile;
 
 import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.monitoring.DesyncMonitoring;
+import com.minecrafttas.tasmod.playback.ControlByteHandler;
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TickInputContainer;
 import com.minecrafttas.tasmod.util.FileThread;
 import com.minecrafttas.tasmod.util.LoggerMarkers;

--- a/src/main/java/com/minecrafttas/tasmod/playback/tasfile/PlaybackSerialiser.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/tasfile/PlaybackSerialiser.java
@@ -108,27 +108,27 @@ public class PlaybackSerialiser {
 		fileThread.start();
 //		monitorThread.start();
 		
-		fileThread.addLine("################################################# TASFile ###################################################\n"
-				 + "#												Version:1													#\n"
-				 + "#							This file was generated using the Minecraft TASMod								#\n"
-				 + "#																											#\n"
-				 + "#			Any errors while reading this file will be printed out in the console and the chat				#\n"
-				 + "#																											#\n"
-				 + "#------------------------------------------------ Header ---------------------------------------------------#\n"
-				 + "#Author:" + container.getAuthors() + "\n"
-				 + "#																											#\n"
-				 + "#Title:" + container.getTitle() + "\n"
-				 + "#																											#\n"
-				 + "#Playing Time:" + container.getPlaytime() + "\n"
-				 + "#																											#\n"
-				 + "#Rerecords:"+container.getRerecords() + "\n"
-				 + "#																											#\n"
-				 + "#----------------------------------------------- Settings --------------------------------------------------#\n"
-				 + "#StartPosition:"+container.getStartLocation()+"\n"
-				 + "#																											#\n"
-				 + "#StartSeed:" + container.getStartSeed() + "\n"
-				 + "#############################################################################################################\n"
-				 + "#Comments start with \"//\" at the start of the line, comments with # will not be saved\n");
+//		fileThread.addLine("################################################# TASFile ###################################################\n"
+//				 + "#												Version:1													#\n"
+//				 + "#							This file was generated using the Minecraft TASMod								#\n"
+//				 + "#																											#\n"
+//				 + "#			Any errors while reading this file will be printed out in the console and the chat				#\n"
+//				 + "#																											#\n"
+//				 + "#------------------------------------------------ Header ---------------------------------------------------#\n"
+//				 + "#Author:" + container.getAuthors() + "\n"
+//				 + "#																											#\n"
+//				 + "#Title:" + container.getTitle() + "\n"
+//				 + "#																											#\n"
+//				 + "#Playing Time:" + container.getPlaytime() + "\n"
+//				 + "#																											#\n"
+//				 + "#Rerecords:"+container.getRerecords() + "\n"
+//				 + "#																											#\n"
+//				 + "#----------------------------------------------- Settings --------------------------------------------------#\n"
+//				 + "#StartPosition:"+container.getStartLocation()+"\n"
+//				 + "#																											#\n"
+//				 + "#StartSeed:" + container.getStartSeed() + "\n"
+//				 + "#############################################################################################################\n"
+//				 + "#Comments start with \"//\" at the start of the line, comments with # will not be saved\n");
 		
 		BigArrayList<TickInputContainer> ticks = container.getInputs();
 		Map<Integer, List<Pair<String, String[]>>> cbytes= container.getControlBytes();
@@ -283,11 +283,11 @@ public class PlaybackSerialiser {
 				}
 			}
 		}
-		controller.setAuthors(author);
-		controller.setTitle(title);
-		controller.setPlaytime(playtime);
-		controller.setRerecords(rerecords);
-		controller.setStartLocation(startLocation);
+//		controller.setAuthors(author);
+//		controller.setTitle(title);
+//		controller.setPlaytime(playtime);
+//		controller.setRerecords(rerecords);
+//		controller.setStartLocation(startLocation);
 		controller.setStartSeed(startSeed);
 		if(!monitorLines.isEmpty()) {
 			controller.desyncMonitor = new DesyncMonitoring(controller, monitorLines);

--- a/src/main/java/com/minecrafttas/tasmod/playback/tasfile/PlaybackSerialiserBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/tasfile/PlaybackSerialiserBase.java
@@ -1,7 +1,9 @@
-package com.minecrafttas.tasmod.playback;
+package com.minecrafttas.tasmod.playback.tasfile;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient;
 
 public abstract class PlaybackSerialiserBase {
 	

--- a/src/main/java/com/minecrafttas/tasmod/playback/tasfile/exception/PlaybackLoadException.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/tasfile/exception/PlaybackLoadException.java
@@ -1,0 +1,12 @@
+package com.minecrafttas.tasmod.playback.tasfile.exception;
+
+public class PlaybackLoadException extends RuntimeException {
+	
+	public PlaybackLoadException(String msg) {
+		super(msg);
+	}
+	
+	public PlaybackLoadException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
@@ -114,7 +114,7 @@ public class VirtualCameraAngle extends Subtickable<VirtualCameraAngle> implemen
 	
     /**
      * Copies the data from another camera angle into this camera without creating a new object.
-     * @param camera The camera to move from
+     * @param camera The camera to copy from
      */
 	public void copyFrom(VirtualCameraAngle camera) {
 		if(camera == null)

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
@@ -117,6 +117,8 @@ public class VirtualCameraAngle extends Subtickable<VirtualCameraAngle> implemen
      * @param camera The camera to move from
      */
 	public void copyFrom(VirtualCameraAngle camera) {
+		if(camera == null)
+			return;
 		this.pitch = camera.pitch;
 		this.yaw = camera.yaw;
 		this.subtickList.clear();

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
@@ -131,7 +131,7 @@ public class VirtualCameraAngle extends Subtickable<VirtualCameraAngle> implemen
      * @param camera The camera to copy from
      */
 	public void deepCopyFrom(VirtualCameraAngle camera) {
-		if(camera == null)
+		if(camera == null || !camera.isParent())
 			return;
 		this.pitch = camera.pitch;
 		this.yaw = camera.yaw;

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
@@ -113,10 +113,10 @@ public class VirtualCameraAngle extends Subtickable<VirtualCameraAngle> implemen
 	}
 	
     /**
-     * Copies the data from another camera angle into this camera without creating a new object.
+     * Moves the data from another camera angle into this camera without creating a new object.
      * @param camera The camera to copy from
      */
-	public void copyFrom(VirtualCameraAngle camera) {
+	public void moveFrom(VirtualCameraAngle camera) {
 		if(camera == null)
 			return;
 		this.pitch = camera.pitch;
@@ -124,6 +124,19 @@ public class VirtualCameraAngle extends Subtickable<VirtualCameraAngle> implemen
 		this.subtickList.clear();
 		this.subtickList.addAll(camera.subtickList);
 		camera.subtickList.clear();
+	}
+	
+    /**
+     * Copies the data from another camera angle into this camera without creating a new object.
+     * @param camera The camera to copy from
+     */
+	public void deepCopyFrom(VirtualCameraAngle camera) {
+		if(camera == null)
+			return;
+		this.pitch = camera.pitch;
+		this.yaw = camera.yaw;
+		this.subtickList.clear();
+		this.subtickList.addAll(camera.subtickList);
 	}
 	
 	/**

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
@@ -1,11 +1,11 @@
 package com.minecrafttas.tasmod.virtual;
 
-import net.minecraft.util.math.MathHelper;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import net.minecraft.util.math.MathHelper;
 
 /**
  * Stores the values of the camera angle of the player in a given timeframe.<br>
@@ -80,10 +80,20 @@ public class VirtualCameraAngle extends Subtickable<VirtualCameraAngle> implemen
 	 * @param yawDelta The difference between absolute coordinates of the yaw, is added to {@link VirtualCameraAngle#yaw}
 	 */
 	public void update(float pitchDelta, float yawDelta) {
+		update(pitchDelta, yawDelta, true);
+	}
+	
+	/**
+	 * Updates the camera angle.
+	 * @param pitchDelta The difference between absolute coordinates of the pitch, is added to {@link VirtualCameraAngle#pitch}
+	 * @param yawDelta The difference between absolute coordinates of the yaw, is added to {@link VirtualCameraAngle#yaw}
+	 * @param updateSubtick If the previous camera should be added to {@link Subtickable#subtickList}
+	 */
+	public void update(float pitchDelta, float yawDelta, boolean updateSubtick) {
 		if(pitch==null || yaw == null) {
 			return;
 		}
-		if(isParent() && !ignoreFirstUpdate()) {
+		if(isParent() && !ignoreFirstUpdate() && updateSubtick) {
 			addSubtick(shallowClone());
 		}
 		this.pitch = MathHelper.clamp(this.pitch + pitchDelta, -90.0F, 90.0F);

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualCameraAngle.java
@@ -84,7 +84,7 @@ public class VirtualCameraAngle extends Subtickable<VirtualCameraAngle> implemen
 			return;
 		}
 		if(isParent() && !ignoreFirstUpdate()) {
-			addSubtick(clone());
+			addSubtick(shallowClone());
 		}
 		this.pitch = MathHelper.clamp(this.pitch + pitchDelta, -90.0F, 90.0F);
 		this.yaw += yawDelta;
@@ -152,9 +152,13 @@ public class VirtualCameraAngle extends Subtickable<VirtualCameraAngle> implemen
 	/**
 	 * Creates a clone of this object as a subtick
 	 */
+	public VirtualCameraAngle shallowClone() {
+		return new VirtualCameraAngle(pitch, yaw);
+	}
+	
 	@Override
 	public VirtualCameraAngle clone() {
-		return new VirtualCameraAngle(pitch, yaw);
+		return new VirtualCameraAngle(pitch, yaw, new ArrayList<>(subtickList), isIgnoreFirstUpdate());
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
@@ -248,7 +248,7 @@ public class VirtualInput {
 		 */
 		public void nextKeyboardTick() {
 			currentKeyboard.getVirtualEvents(nextKeyboard, keyboardEventQueue);
-			currentKeyboard.copyFrom(nextKeyboard);
+			currentKeyboard.moveFrom(nextKeyboard);
 		}
 
 		/**
@@ -406,9 +406,9 @@ public class VirtualInput {
 		 * @see MixinMinecraft#playback_injectRunTickMouse(org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
 		 */
 		public void nextMouseTick() {
-			nextMouse.copyFrom((VirtualMouse) EventListenerRegistry.fireEvent(EventVirtualMouseTick.class, nextMouse));
+			nextMouse.moveFrom((VirtualMouse) EventListenerRegistry.fireEvent(EventVirtualMouseTick.class, nextMouse));
 			currentMouse.getVirtualEvents(nextMouse, mouseEventQueue);
-			currentMouse.copyFrom(nextMouse);
+			currentMouse.moveFrom(nextMouse);
 		}
 
 		/**

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
@@ -11,6 +11,9 @@ import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
+import com.minecrafttas.tasmod.events.EventClient.EventVirtualCameraAngleTick;
+import com.minecrafttas.tasmod.events.EventClient.EventVirtualMouseTick;
 import com.minecrafttas.tasmod.mixin.playbackhooks.MixinEntityRenderer;
 import com.minecrafttas.tasmod.mixin.playbackhooks.MixinMinecraft;
 import com.minecrafttas.tasmod.util.Ducks;
@@ -403,6 +406,7 @@ public class VirtualInput {
 		 * @see MixinMinecraft#playback_injectRunTickMouse(org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
 		 */
 		public void nextMouseTick() {
+			nextMouse.copyFrom((VirtualMouse) EventListenerRegistry.fireEvent(EventVirtualMouseTick.class, nextMouse));
 			currentMouse.getVirtualEvents(nextMouse, mouseEventQueue);
 			currentMouse.copyFrom(nextMouse);
 		}
@@ -588,6 +592,7 @@ public class VirtualInput {
 		 * @see MixinEntityRenderer#runUpdate(float)
 		 */
 		public void nextCameraTick() {
+			nextCameraAngle.copyFrom((VirtualCameraAngle) EventListenerRegistry.fireEvent(EventVirtualCameraAngleTick.class, nextCameraAngle));
 			nextCameraAngle.getStates(cameraAngleInterpolationStates);
 			currentCameraAngle.copyFrom(nextCameraAngle);
 		}

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
@@ -13,6 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import com.minecrafttas.tasmod.events.EventClient.EventVirtualCameraAngleTick;
+import com.minecrafttas.tasmod.events.EventClient.EventVirtualKeyboardTick;
 import com.minecrafttas.tasmod.events.EventClient.EventVirtualMouseTick;
 import com.minecrafttas.tasmod.mixin.playbackhooks.MixinEntityRenderer;
 import com.minecrafttas.tasmod.mixin.playbackhooks.MixinMinecraft;
@@ -247,6 +248,7 @@ public class VirtualInput {
 		 * @see MixinMinecraft#playback_injectRunTickKeyboard(org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
 		 */
 		public void nextKeyboardTick() {
+			nextKeyboard.deepCopyFrom((VirtualKeyboard) EventListenerRegistry.fireEvent(EventVirtualKeyboardTick.class, nextKeyboard));
 			currentKeyboard.getVirtualEvents(nextKeyboard, keyboardEventQueue);
 			currentKeyboard.moveFrom(nextKeyboard);
 		}
@@ -406,7 +408,7 @@ public class VirtualInput {
 		 * @see MixinMinecraft#playback_injectRunTickMouse(org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
 		 */
 		public void nextMouseTick() {
-			EventListenerRegistry.fireEvent(EventVirtualMouseTick.class, nextMouse);
+			nextMouse.deepCopyFrom((VirtualMouse) EventListenerRegistry.fireEvent(EventVirtualMouseTick.class, nextMouse));
 			currentMouse.getVirtualEvents(nextMouse, mouseEventQueue);
 			currentMouse.moveFrom(nextMouse);
 		}
@@ -592,7 +594,7 @@ public class VirtualInput {
 		 * @see MixinEntityRenderer#runUpdate(float)
 		 */
 		public void nextCameraTick() {
-			nextCameraAngle.moveFrom((VirtualCameraAngle) EventListenerRegistry.fireEvent(EventVirtualCameraAngleTick.class, nextCameraAngle));
+			nextCameraAngle.deepCopyFrom((VirtualCameraAngle) EventListenerRegistry.fireEvent(EventVirtualCameraAngleTick.class, nextCameraAngle));
 			nextCameraAngle.getStates(cameraAngleInterpolationStates);
 			currentCameraAngle.moveFrom(nextCameraAngle);
 		}
@@ -651,7 +653,7 @@ public class VirtualInput {
 				interpolatedYaw = (float) MathHelper.clampedLerp(currentCameraAngle.getYaw(), cameraAngleInterpolationStates.get(0).getYaw() + 180, partialTick);
 			} else {
 
-				int index = (int) MathHelper.clampedLerp(0, cameraAngleInterpolationStates.size(), partialTick); // Get interpolate index
+				int index = (int) MathHelper.clampedLerp(0, cameraAngleInterpolationStates.size()-1, partialTick); // Get interpolate index
 
 				interpolatedPitch = cameraAngleInterpolationStates.get(index).getPitch();
 				interpolatedYaw = cameraAngleInterpolationStates.get(index).getYaw();

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
@@ -406,7 +406,7 @@ public class VirtualInput {
 		 * @see MixinMinecraft#playback_injectRunTickMouse(org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
 		 */
 		public void nextMouseTick() {
-			nextMouse.moveFrom((VirtualMouse) EventListenerRegistry.fireEvent(EventVirtualMouseTick.class, nextMouse));
+			EventListenerRegistry.fireEvent(EventVirtualMouseTick.class, nextMouse);
 			currentMouse.getVirtualEvents(nextMouse, mouseEventQueue);
 			currentMouse.moveFrom(nextMouse);
 		}
@@ -592,9 +592,9 @@ public class VirtualInput {
 		 * @see MixinEntityRenderer#runUpdate(float)
 		 */
 		public void nextCameraTick() {
-			nextCameraAngle.copyFrom((VirtualCameraAngle) EventListenerRegistry.fireEvent(EventVirtualCameraAngleTick.class, nextCameraAngle));
+			nextCameraAngle.moveFrom((VirtualCameraAngle) EventListenerRegistry.fireEvent(EventVirtualCameraAngleTick.class, nextCameraAngle));
 			nextCameraAngle.getStates(cameraAngleInterpolationStates);
-			currentCameraAngle.copyFrom(nextCameraAngle);
+			currentCameraAngle.moveFrom(nextCameraAngle);
 		}
 
 		/**

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
@@ -658,7 +658,7 @@ public class VirtualInput {
 		public Triple<Float, Float, Float> getInterpolatedState(float partialTick, float pitch, float yaw, boolean enable) {
 			
 			float interpolatedPitch = nextCameraAngle.getPitch() == null ? pitch : nextCameraAngle.getPitch();
-			float interpolatedYaw = nextCameraAngle.getYaw() == null ? pitch : nextCameraAngle.getYaw() + 180;
+			float interpolatedYaw = nextCameraAngle.getYaw() == null ? yaw : nextCameraAngle.getYaw() + 180;
 
 			if (enable && !cameraAngleInterpolationStates.isEmpty()) {
 				int index = (int) MathHelper.clampedLerp(0, cameraAngleInterpolationStates.size() - 1, partialTick); // Get interpolate index

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeybindings.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeybindings.java
@@ -7,7 +7,6 @@ import java.util.List;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
-import com.google.common.collect.Maps;
 import com.minecrafttas.tasmod.TASmodClient;
 
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeyboard.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeyboard.java
@@ -289,13 +289,22 @@ public class VirtualKeyboard extends VirtualPeripheral<VirtualKeyboard> implemen
     }
     
     @Override
-    public void copyFrom(VirtualKeyboard keyboard) {
+    public void moveFrom(VirtualKeyboard keyboard) {
+    	if(keyboard == null)
+    		return;
+    	super.moveFrom(keyboard);
+    	charList.clear();
+    	charList.addAll(keyboard.charList);
+    	keyboard.charList.clear();
+    }
+    
+    @Override
+	public void copyFrom(VirtualKeyboard keyboard) {
     	if(keyboard == null)
     		return;
     	super.copyFrom(keyboard);
     	charList.clear();
     	charList.addAll(keyboard.charList);
-    	keyboard.charList.clear();
     }
     
     @Override

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeyboard.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeyboard.java
@@ -290,6 +290,8 @@ public class VirtualKeyboard extends VirtualPeripheral<VirtualKeyboard> implemen
     
     @Override
     public void copyFrom(VirtualKeyboard keyboard) {
+    	if(keyboard == null)
+    		return;
     	super.copyFrom(keyboard);
     	charList.clear();
     	charList.addAll(keyboard.charList);

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeyboard.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeyboard.java
@@ -127,7 +127,7 @@ public class VirtualKeyboard extends VirtualPeripheral<VirtualKeyboard> implemen
      */
     public void update(int keycode, boolean keystate, char keycharacter, boolean repeatEventsEnabled) {
     	if(isParent() && !ignoreFirstUpdate()) {
-    		addSubtick(clone());
+    		addSubtick(shallowClone());
     	}
     	charList.clear();
 		if (keystate) {
@@ -138,6 +138,14 @@ public class VirtualKeyboard extends VirtualPeripheral<VirtualKeyboard> implemen
     
     public void update(int keycode, boolean keystate, char keycharacter) {
     	update(keycode, keystate, keycharacter, false);
+    }
+    
+    public void update(VirtualKey key, boolean keystate, char keycharacter) {
+    	update(key.getKeycode(), keystate, keycharacter);
+    }
+    
+    public void update(VirtualKey key, boolean keystate, char keycharacter, boolean repeatEventsEnabled) {
+    	update(key.getKeycode(), keystate, keycharacter, false);
     }
     
     @Override
@@ -281,12 +289,16 @@ public class VirtualKeyboard extends VirtualPeripheral<VirtualKeyboard> implemen
 	}
 
 	/**
-	 * Clones this VirtualKeyboard <strong>without</strong> subticks
+	 * Clones this VirtualKeyboard <strong>without</strong> subticks.
 	 */
-    @Override
-	public VirtualKeyboard clone() {
+	public VirtualKeyboard shallowClone() {
         return new VirtualKeyboard(new HashSet<>(this.pressedKeys), new ArrayList<>(this.charList), isIgnoreFirstUpdate());
     }
+	
+	@Override
+	public VirtualKeyboard clone(){
+		return new VirtualKeyboard(new HashSet<>(this.pressedKeys), new ArrayList<>(this.charList), new ArrayList<>(subtickList), isIgnoreFirstUpdate());
+	}
     
     @Override
     public void moveFrom(VirtualKeyboard keyboard) {

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeyboard.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualKeyboard.java
@@ -308,6 +308,15 @@ public class VirtualKeyboard extends VirtualPeripheral<VirtualKeyboard> implemen
     }
     
     @Override
+    public void deepCopyFrom(VirtualKeyboard keyboard) {
+    	if(keyboard == null)
+    		return;
+    	super.deepCopyFrom(keyboard);
+    	charList.clear();
+    	charList.addAll(keyboard.charList);
+    }
+    
+    @Override
     public boolean equals(Object obj) {
     	if(obj instanceof VirtualKeyboard) {
     		VirtualKeyboard keyboard = (VirtualKeyboard) obj;

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
@@ -227,6 +227,8 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 
 	@Override
 	public void copyFrom(VirtualMouse mouse) {
+		if(mouse==null)
+			return;
 		super.copyFrom(mouse);
 		this.scrollWheel = mouse.scrollWheel;
 		this.cursorX = mouse.cursorX;

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
@@ -226,6 +226,17 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 	}
 
 	@Override
+	public void moveFrom(VirtualMouse mouse) {
+		if(mouse==null)
+			return;
+		super.moveFrom(mouse);
+		this.scrollWheel = mouse.scrollWheel;
+		this.cursorX = mouse.cursorX;
+		this.cursorY = mouse.cursorY;
+		mouse.clearMouseData();
+	}
+	
+	@Override
 	public void copyFrom(VirtualMouse mouse) {
 		if(mouse==null)
 			return;
@@ -233,7 +244,6 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 		this.scrollWheel = mouse.scrollWheel;
 		this.cursorX = mouse.cursorX;
 		this.cursorY = mouse.cursorY;
-		mouse.clearMouseData();
 	}
 	
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
@@ -73,7 +73,7 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 	 * @param scrollWheel		The {@link #scrollWheel}
 	 * @param cursorX			The {@link #cursorX}
 	 * @param cursorY			The {@link #cursorY}
-	 * @param subtickList			The {@link VirtualPeripheral#subtickList}
+	 * @param subtickList		The {@link VirtualPeripheral#subtickList}
 	 * @param ignoreFirstUpdate	Whether the first call to {@link #update(int, boolean, int, Integer, Integer)} should create a new subtick
 	 */
 	public VirtualMouse(Set<Integer> pressedKeys, int scrollWheel, Integer cursorX, Integer cursorY, List<VirtualMouse> subtickList, boolean ignoreFirstUpdate) {
@@ -241,6 +241,16 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 		if(mouse==null)
 			return;
 		super.copyFrom(mouse);
+		this.scrollWheel = mouse.scrollWheel;
+		this.cursorX = mouse.cursorX;
+		this.cursorY = mouse.cursorY;
+	}
+	
+	@Override
+	public void deepCopyFrom(VirtualMouse mouse) {
+		if(mouse==null)
+			return;
+		super.deepCopyFrom(mouse);
 		this.scrollWheel = mouse.scrollWheel;
 		this.cursorX = mouse.cursorX;
 		this.cursorY = mouse.cursorY;

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
@@ -85,7 +85,7 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 
 	public void update(int keycode, boolean keystate, int scrollwheel, Integer cursorX, Integer cursorY) {
     	if(isParent() && !ignoreFirstUpdate()) {
-    		addSubtick(clone());
+    		addSubtick(shallowClone());
     	}
 		setPressed(keycode, keystate);
 		this.scrollWheel = scrollwheel;
@@ -220,9 +220,13 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 	/**
 	 * Clones this VirtualMouse <strong>without</strong> subticks
 	 */
+	public VirtualMouse shallowClone() {
+		return new VirtualMouse(new HashSet<>(this.pressedKeys), scrollWheel, cursorX, cursorY, null, ignoreFirstUpdate());
+	}
+	
 	@Override
 	public VirtualMouse clone() {
-		return new VirtualMouse(new HashSet<>(this.pressedKeys), scrollWheel, cursorX, cursorY, null, ignoreFirstUpdate());
+		return new VirtualMouse(new HashSet<>(this.pressedKeys), scrollWheel, cursorX, cursorY, new ArrayList<>(subtickList), isIgnoreFirstUpdate());
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
@@ -83,14 +83,35 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 		this.cursorY = cursorY;
 	}
 
+    /**
+     * Updates the mouse, adds a new subtick to this mouse
+     * @param keycode The keycode of this button
+     * @param keystate The keystate of this button, true for pressed
+     * @param scrollwheel The scroll wheel for this mouse
+     * @oaram cursorX The pointer location in the x axis
+     * @param cursorY The pointer location in the y axis
+     */
 	public void update(int keycode, boolean keystate, int scrollwheel, Integer cursorX, Integer cursorY) {
-    	if(isParent() && !ignoreFirstUpdate()) {
-    		addSubtick(shallowClone());
-    	}
+		if (isParent() && !ignoreFirstUpdate()) {
+			addSubtick(shallowClone());
+		}
 		setPressed(keycode, keystate);
 		this.scrollWheel = scrollwheel;
 		this.cursorX = cursorX;
 		this.cursorY = cursorY;
+	}
+
+	/**
+	 * Updates the mouse, adds a new subtick to this mouse
+	 * 
+	 * @param key         The key
+	 * @param keystate    The keystate of this button, true for pressed
+	 * @param scrollwheel The scroll wheel for this mouse
+	 * @oaram cursorX The pointer location in the x axis
+	 * @param cursorY The pointer location in the y axis
+	 */
+	public void update(VirtualKey key, boolean keystate, int scrollwheel, Integer cursorX, Integer cursorY) {
+		update(key.getKeycode(), keystate, scrollwheel, cursorX, cursorY);
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualMouse.java
@@ -258,7 +258,7 @@ public class VirtualMouse extends VirtualPeripheral<VirtualMouse> implements Ser
 		this.scrollWheel = mouse.scrollWheel;
 		this.cursorX = mouse.cursorX;
 		this.cursorY = mouse.cursorY;
-		mouse.clearMouseData();
+		mouse.scrollWheel=0;
 	}
 	
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
@@ -134,17 +134,29 @@ public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends 
 	}
 
 	/**
-	 * Copies the data from another virtual peripheral into this peripheral without
-	 * creating a new object.
+	 * Moves the data from another virtual peripheral into this peripheral without
+	 * creating a new object. Deletes the data in the other peripheral
 	 * 
 	 * @param peripheral The peripheral to move from
+	 */
+	protected void moveFrom(T peripheral) {
+		if(peripheral == null)
+			return;
+		copyFrom(peripheral);
+		peripheral.subtickList.clear();
+		peripheral.resetFirstUpdate();
+	}
+	
+	/**
+	 * Copies the data from another virtual peripheral into this peripheral without creating a new object.<br>
+	 * Does not delete the data from the other peripehral
+	 * 
+	 * @param peripheral The peripheral to copy from
 	 */
 	protected void copyFrom(T peripheral) {
 		if(peripheral == null)
 			return;
 		this.pressedKeys.clear();
 		this.pressedKeys.addAll(peripheral.pressedKeys);
-		peripheral.subtickList.clear();
-		peripheral.resetFirstUpdate();
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
@@ -140,6 +140,8 @@ public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends 
 	 * @param peripheral The peripheral to move from
 	 */
 	protected void copyFrom(T peripheral) {
+		if(peripheral == null)
+			return;
 		this.pressedKeys.clear();
 		this.pressedKeys.addAll(peripheral.pressedKeys);
 		peripheral.subtickList.clear();

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
@@ -134,8 +134,9 @@ public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends 
 	}
 
 	/**
-	 * Moves the data from another virtual peripheral into this peripheral without
-	 * creating a new object. Deletes the data in the other peripheral
+	 * Moves the data from another virtual peripheral into this peripheral without creating a new object.<br>
+	 * Deletes the data in the other peripheral.<br>
+	 * <strong>Ignores {@link com.minecrafttas.tasmod.virtual.Subtickable.subtickList}</strong>
 	 * 
 	 * @param peripheral The peripheral to move from
 	 */
@@ -149,7 +150,8 @@ public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends 
 	
 	/**
 	 * Copies the data from another virtual peripheral into this peripheral without creating a new object.<br>
-	 * Does not delete the data from the other peripehral
+	 * Does not delete the data from the other peripehral.<br>
+	 * <strong>Ignores {@link com.minecrafttas.tasmod.virtual.Subtickable.subtickList}</strong>
 	 * 
 	 * @param peripheral The peripheral to copy from
 	 */
@@ -158,5 +160,17 @@ public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends 
 			return;
 		this.pressedKeys.clear();
 		this.pressedKeys.addAll(peripheral.pressedKeys);
+	}
+	
+	/**
+	 * Copies the data from another virtual peripheral similar to {@link #copyFrom(VirtualPeripheral)}, but including the {@link com.minecrafttas.tasmod.virtual.Subtickable.subtickList}
+	 * @param peripheral
+	 */
+	protected void deepCopyFrom(T peripheral) {
+		if(peripheral == null || !peripheral.isParent())
+			return;
+		copyFrom(peripheral);
+		this.subtickList.clear();
+		this.subtickList.addAll(peripheral.subtickList);
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
@@ -173,4 +173,5 @@ public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends 
 		this.subtickList.clear();
 		this.subtickList.addAll(peripheral.subtickList);
 	}
+	
 }

--- a/src/test/java/mctcommon/event/EventTest.java
+++ b/src/test/java/mctcommon/event/EventTest.java
@@ -119,10 +119,6 @@ public class EventTest {
 
         class TestClass implements TestEvent {
 
-            public int onTestEvent(int test) {
-                return test;
-            }
-
             @Override
             public int onTestEvent() {
                 return 1;

--- a/src/test/java/mctcommon/event/EventTest.java
+++ b/src/test/java/mctcommon/event/EventTest.java
@@ -160,6 +160,9 @@ public class EventTest {
 
         EventListenerRegistry.unregister(event);
 
-        assertNull(EventListenerRegistry.fireEvent(TestEvent.class));
+        Exception exception = assertThrows(EventException.class, () -> EventListenerRegistry.fireEvent(TestEvent.class));
+
+        String expected = "mctcommon.event.EventTest$TestEvent: The event has not been registered yet";
+        assertEquals(expected, exception.getMessage());
     }
 }

--- a/src/test/java/mctcommon/event/EventTest.java
+++ b/src/test/java/mctcommon/event/EventTest.java
@@ -160,9 +160,7 @@ public class EventTest {
 
         EventListenerRegistry.unregister(event);
 
-        Exception exception = assertThrows(EventException.class, () -> EventListenerRegistry.fireEvent(TestEvent.class));
-
-        String expected = "mctcommon.event.EventTest$TestEvent: The event has not been registered yet";
-        assertEquals(expected, exception.getMessage());
+        EventListenerRegistry.fireEvent(TestEvent.class);
+        return;
     }
 }

--- a/src/test/java/tasmod/playback/metadata/PlaybackMetadataRegistryTest.java
+++ b/src/test/java/tasmod/playback/metadata/PlaybackMetadataRegistryTest.java
@@ -46,6 +46,10 @@ public class PlaybackMetadataRegistryTest {
 		public void onLoad(PlaybackMetadata metadata) {
 			actual = metadata.getValue("Test");
 		}
+
+		@Override
+		public void onClear() {
+		}
 		
 	}
 	

--- a/src/test/java/tasmod/playback/metadata/PlaybackMetadataTest.java
+++ b/src/test/java/tasmod/playback/metadata/PlaybackMetadataTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,26 +11,45 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
+import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadataRegistry.PlaybackMetadataExtension;
 
 public class PlaybackMetadataTest {
 
-	@Test
-	void testConstructor() {
-		PlaybackMetadata metadata = new PlaybackMetadata();
-		assertNotNull(metadata.getMetadata());
-		assertNull(metadata.getExtensionName());
+	class MetadataTest implements PlaybackMetadataExtension{
+
+		@Override
+		public String getExtensionName() {
+			return "Test";
+		}
+
+		@Override
+		public void onCreate() {
+			
+		}
+
+		@Override
+		public PlaybackMetadata onStore() {
+			return null;
+		}
+
+		@Override
+		public void onLoad(PlaybackMetadata metadata) {
+		}
+		
 	}
 	
 	@Test
-	void testNameConstructor() {
-		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+	void testConstructor() {
+		MetadataTest test = new MetadataTest();
+		PlaybackMetadata metadata = new PlaybackMetadata(test);
 		assertNotNull(metadata.getMetadata());
 		assertEquals("Test", metadata.getExtensionName());
 	}
 	
 	@Test
 	void testSettingAndReading() {
-		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		MetadataTest test = new MetadataTest();
+		PlaybackMetadata metadata = new PlaybackMetadata(test);
 		metadata.setValue("testProperty", "Test");
 		
 		String actual = metadata.getValue("testProperty");
@@ -41,7 +59,8 @@ public class PlaybackMetadataTest {
 	
 	@Test
 	void testToString() {
-		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		MetadataTest test = new MetadataTest();
+		PlaybackMetadata metadata = new PlaybackMetadata(test);
 		metadata.setValue("1", "One");
 		metadata.setValue("2", "Two");
 		metadata.setValue("3", "Three");
@@ -49,17 +68,18 @@ public class PlaybackMetadataTest {
 		
 		String actual = metadata.toString();
 		
-		String expected = "1=One\n"
-				+ "2=Two\n"
-				+ "3=Three\n"
-				+ "4=Four\n";
+		String expected = "1:One\n"
+				+ "2:Two\n"
+				+ "3:Three\n"
+				+ "4:Four\n";
 		
 		assertEquals(expected, actual);
 	}
 	
 	@Test
 	void testToStringList() {
-		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		MetadataTest test = new MetadataTest();
+		PlaybackMetadata metadata = new PlaybackMetadata(test);
 		metadata.setValue("1", "One");
 		metadata.setValue("2", "Two");
 		metadata.setValue("3", "Three");
@@ -68,23 +88,25 @@ public class PlaybackMetadataTest {
 		List<String> actual = metadata.toStringList();
 		
 		List<String> expected = new ArrayList<>();
-		expected.add("1=One\n");
-		expected.add("2=Two\n");
-		expected.add("3=Three\n");
-		expected.add("4=Four\n");
+		expected.add("1:One\n");
+		expected.add("2:Two\n");
+		expected.add("3:Three\n");
+		expected.add("4:Four\n");
 		
 		assertIterableEquals(expected, actual);
 	}
 	
 	@Test
 	void testEquals() {
-		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		MetadataTest test = new MetadataTest();
+		PlaybackMetadata metadata = new PlaybackMetadata(test);
 		metadata.setValue("1", "One");
 		metadata.setValue("2", "Two");
 		metadata.setValue("3", "Three");
 		metadata.setValue("4", "Four");
 		
-		PlaybackMetadata metadata2 = new PlaybackMetadata("Test");
+		MetadataTest test2 = new MetadataTest();
+		PlaybackMetadata metadata2 = new PlaybackMetadata(test2);
 		metadata2.setValue("1", "One");
 		metadata2.setValue("2", "Two");
 		metadata2.setValue("3", "Three");
@@ -96,13 +118,15 @@ public class PlaybackMetadataTest {
 	@Test
 	void testFailedEquals() {
 		//Key difference
-		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		MetadataTest test = new MetadataTest();
+		PlaybackMetadata metadata = new PlaybackMetadata(test);
 		metadata.setValue("2", "One");
 		metadata.setValue("2", "Two");
 		metadata.setValue("3", "Three");
 		metadata.setValue("4", "Four");
 		
-		PlaybackMetadata metadata2 = new PlaybackMetadata("Test");
+		MetadataTest test2 = new MetadataTest();
+		PlaybackMetadata metadata2 = new PlaybackMetadata(test2);
 		metadata2.setValue("1", "One");
 		metadata2.setValue("2", "Two");
 		metadata2.setValue("3", "Three");
@@ -111,13 +135,13 @@ public class PlaybackMetadataTest {
 		assertNotEquals(metadata, metadata2);
 		
 		// Value difference
-		metadata = new PlaybackMetadata("Test");
+		metadata = new PlaybackMetadata(test);
 		metadata.setValue("1", "On");
 		metadata.setValue("2", "Two");
 		metadata.setValue("3", "Three");
 		metadata.setValue("4", "Four");
 		
-		metadata2 = new PlaybackMetadata("Test");
+		metadata2 = new PlaybackMetadata(test);
 		metadata2.setValue("1", "One");
 		metadata2.setValue("2", "Two");
 		metadata2.setValue("3", "Three");
@@ -126,17 +150,20 @@ public class PlaybackMetadataTest {
 		assertNotEquals(metadata, metadata2);
 		
 		// Name difference
-		metadata = new PlaybackMetadata("Tes");
+		metadata2 = new PlaybackMetadata(test);
 		metadata.setValue("1", "One");
 		metadata.setValue("2", "Two");
 		metadata.setValue("3", "Three");
 		metadata.setValue("4", "Four");
 		
-		metadata2 = new PlaybackMetadata("Test");
-		metadata2.setValue("1", "One");
-		metadata2.setValue("2", "Two");
-		metadata2.setValue("3", "Three");
-		metadata2.setValue("4", "Four");
+		
+		List<String> list = new ArrayList<>();
+		list.add("1:One");
+		list.add("2:Two");
+		list.add("3:Three");
+		list.add("4:Four");
+		
+		metadata2 = PlaybackMetadata.fromStringList("Tes", list);
 		
 		assertNotEquals(metadata, metadata2);
 	}

--- a/src/test/java/tasmod/playback/metadata/PlaybackMetadataTest.java
+++ b/src/test/java/tasmod/playback/metadata/PlaybackMetadataTest.java
@@ -1,0 +1,40 @@
+package tasmod.playback.metadata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
+
+public class PlaybackMetadataTest {
+
+	@Test
+	void testConstructor() {
+		PlaybackMetadata metadata = new PlaybackMetadata();
+		assertNotNull(metadata.getMetadata());
+		assertNull(metadata.getExtensionName());
+	}
+	
+	@Test
+	void testNameConstructor() {
+		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		assertNotNull(metadata.getMetadata());
+		assertEquals("Test", metadata.getExtensionName());
+	}
+	
+	@Test
+	void testSettingAndReading() {
+		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		metadata.setValue("testProperty", "Test");
+		
+		String actual = metadata.getValue("testProperty");
+		
+		assertEquals("Test", actual);
+	}
+	
+	
+}

--- a/src/test/java/tasmod/playback/metadata/PlaybackMetadataTest.java
+++ b/src/test/java/tasmod/playback/metadata/PlaybackMetadataTest.java
@@ -1,10 +1,13 @@
 package tasmod.playback.metadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.Properties;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,5 +39,105 @@ public class PlaybackMetadataTest {
 		assertEquals("Test", actual);
 	}
 	
+	@Test
+	void testToString() {
+		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		metadata.setValue("1", "One");
+		metadata.setValue("2", "Two");
+		metadata.setValue("3", "Three");
+		metadata.setValue("4", "Four");
+		
+		String actual = metadata.toString();
+		
+		String expected = "1=One\n"
+				+ "2=Two\n"
+				+ "3=Three\n"
+				+ "4=Four\n";
+		
+		assertEquals(expected, actual);
+	}
 	
+	@Test
+	void testToStringList() {
+		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		metadata.setValue("1", "One");
+		metadata.setValue("2", "Two");
+		metadata.setValue("3", "Three");
+		metadata.setValue("4", "Four");
+		
+		List<String> actual = metadata.toStringList();
+		
+		List<String> expected = new ArrayList<>();
+		expected.add("1=One\n");
+		expected.add("2=Two\n");
+		expected.add("3=Three\n");
+		expected.add("4=Four\n");
+		
+		assertIterableEquals(expected, actual);
+	}
+	
+	@Test
+	void testEquals() {
+		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		metadata.setValue("1", "One");
+		metadata.setValue("2", "Two");
+		metadata.setValue("3", "Three");
+		metadata.setValue("4", "Four");
+		
+		PlaybackMetadata metadata2 = new PlaybackMetadata("Test");
+		metadata2.setValue("1", "One");
+		metadata2.setValue("2", "Two");
+		metadata2.setValue("3", "Three");
+		metadata2.setValue("4", "Four");
+		
+		assertEquals(metadata, metadata2);
+	}
+	
+	@Test
+	void testFailedEquals() {
+		//Key difference
+		PlaybackMetadata metadata = new PlaybackMetadata("Test");
+		metadata.setValue("2", "One");
+		metadata.setValue("2", "Two");
+		metadata.setValue("3", "Three");
+		metadata.setValue("4", "Four");
+		
+		PlaybackMetadata metadata2 = new PlaybackMetadata("Test");
+		metadata2.setValue("1", "One");
+		metadata2.setValue("2", "Two");
+		metadata2.setValue("3", "Three");
+		metadata2.setValue("4", "Four");
+		
+		assertNotEquals(metadata, metadata2);
+		
+		// Value difference
+		metadata = new PlaybackMetadata("Test");
+		metadata.setValue("1", "On");
+		metadata.setValue("2", "Two");
+		metadata.setValue("3", "Three");
+		metadata.setValue("4", "Four");
+		
+		metadata2 = new PlaybackMetadata("Test");
+		metadata2.setValue("1", "One");
+		metadata2.setValue("2", "Two");
+		metadata2.setValue("3", "Three");
+		metadata2.setValue("4", "Four");
+		
+		assertNotEquals(metadata, metadata2);
+		
+		// Name difference
+		metadata = new PlaybackMetadata("Tes");
+		metadata.setValue("1", "One");
+		metadata.setValue("2", "Two");
+		metadata.setValue("3", "Three");
+		metadata.setValue("4", "Four");
+		
+		metadata2 = new PlaybackMetadata("Test");
+		metadata2.setValue("1", "One");
+		metadata2.setValue("2", "Two");
+		metadata2.setValue("3", "Three");
+		metadata2.setValue("4", "Four");
+		
+		assertNotEquals(metadata, metadata2);
+	}
 }

--- a/src/test/java/tasmod/playback/metadata/PlaybackMetadataTest.java
+++ b/src/test/java/tasmod/playback/metadata/PlaybackMetadataTest.java
@@ -35,6 +35,10 @@ public class PlaybackMetadataTest {
 		@Override
 		public void onLoad(PlaybackMetadata metadata) {
 		}
+
+		@Override
+		public void onClear() {
+		}
 		
 	}
 	

--- a/src/test/java/tasmod/virtual/VirtualCameraAngleTest.java
+++ b/src/test/java/tasmod/virtual/VirtualCameraAngleTest.java
@@ -142,10 +142,10 @@ public class VirtualCameraAngleTest {
 	}
 
 	/**
-	 * Test copyfrom method
+	 * Test copyFrom method
 	 */
 	@Test
-	void copyFrom() {
+	void testCopyFrom() {
 		VirtualCameraAngle expected = new VirtualCameraAngle(0f, 0f, true);
 		expected.update(1f, 2f);
 		expected.update(3f, 4f);

--- a/src/test/java/tasmod/virtual/VirtualCameraAngleTest.java
+++ b/src/test/java/tasmod/virtual/VirtualCameraAngleTest.java
@@ -152,7 +152,7 @@ public class VirtualCameraAngleTest {
 		
 		VirtualCameraAngle actual = new VirtualCameraAngle(0f, 0f, true);
 		
-		actual.copyFrom(expected);
+		actual.moveFrom(expected);
 		
 		// Test pitch and yaw
 		assertEquals(expected.getPitch(), actual.getPitch());

--- a/src/test/java/tasmod/virtual/VirtualCameraAngleTest.java
+++ b/src/test/java/tasmod/virtual/VirtualCameraAngleTest.java
@@ -214,20 +214,22 @@ public class VirtualCameraAngleTest {
 	}
 
 	/**
-	 * Test cloning the camera angle
+	 * Test shallow cloning the camera angle
 	 */
 	@Test
-	void testClone() {
+	void testShallowClone() {
 		float x = 1f;
 		float y = 2f;
 
 		VirtualCameraAngle test = new VirtualCameraAngle(x, y);
 
-		VirtualCameraAngle actual = test.clone();
+		VirtualCameraAngle actual = test.shallowClone();
 
 		assertEquals(1f, actual.getPitch());
 		assertEquals(2f, actual.getYaw());
 	}
+	
+	// DeepCloning
 
 	/**
 	 * Test equals

--- a/src/test/java/tasmod/virtual/VirtualInputEventFiring.java
+++ b/src/test/java/tasmod/virtual/VirtualInputEventFiring.java
@@ -1,0 +1,66 @@
+package tasmod.virtual;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
+import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
+import com.minecrafttas.tasmod.virtual.VirtualKey;
+import com.minecrafttas.tasmod.virtual.VirtualKeyboard;
+
+public class VirtualInputEventFiring {
+	
+	interface EventTest extends EventBase{
+		
+		void onTest(VirtualKeyboard keyboard);
+	}
+	
+	interface EventCopy extends EventBase{
+		
+		void onCopy(VirtualKeyboard keyboard);
+	}
+	
+	@BeforeAll
+	static void beforeAll() {
+		EventTest clear = (keyboard)-> {
+			keyboard.clear();
+		};
+		EventCopy copy = (keyboard)-> {
+			VirtualKeyboard newkeyboard = new VirtualKeyboard();
+			newkeyboard.update(VirtualKey.A, true, 'a');
+			newkeyboard.update(VirtualKey.D, true, 'd');
+			keyboard.deepCopyFrom(newkeyboard);
+		};
+		EventListenerRegistry.register(clear, copy);
+	}
+	
+	@Test
+	void testClear() {
+		VirtualKeyboard keyboard = new VirtualKeyboard();
+		
+		keyboard.update(VirtualKey.W, true, 'w');
+		keyboard.update(VirtualKey.S, true, 's');
+		
+		EventListenerRegistry.fireEvent(EventTest.class, keyboard);
+		
+		assertTrue(keyboard.getPressedKeys().isEmpty());
+	}
+	
+	@Test
+	void testCopy() {
+		
+		VirtualKeyboard actual = new VirtualKeyboard();
+		
+		actual.update(VirtualKey.W, true, 'w');
+		actual.update(VirtualKey.S, true, 's');
+		
+		VirtualKeyboard expected = new VirtualKeyboard();
+		expected.update(VirtualKey.A, true, 'a');
+		expected.update(VirtualKey.D, true, 'd');
+		
+		EventListenerRegistry.fireEvent(EventCopy.class, actual);
+		
+		assertEquals(expected, actual);
+	}
+}

--- a/src/test/java/tasmod/virtual/VirtualInputTest.java
+++ b/src/test/java/tasmod/virtual/VirtualInputTest.java
@@ -8,9 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
+import com.minecrafttas.tasmod.events.EventClient.EventVirtualCameraAngleTick;
+import com.minecrafttas.tasmod.events.EventClient.EventVirtualKeyboardTick;
+import com.minecrafttas.tasmod.events.EventClient.EventVirtualMouseTick;
 import com.minecrafttas.tasmod.virtual.VirtualCameraAngle;
 import com.minecrafttas.tasmod.virtual.VirtualInput;
 import com.minecrafttas.tasmod.virtual.VirtualKey;
@@ -20,6 +25,14 @@ import com.minecrafttas.tasmod.virtual.VirtualMouse;
 class VirtualInputTest {
 
 	private final Logger LOGGER = LogManager.getLogger("TASmod");
+	
+	@BeforeAll
+	static void beforeAll() {
+		EventVirtualKeyboardTick kb = (keyboard)->null;
+		EventVirtualMouseTick ms = (mouse)->null;
+		EventVirtualCameraAngleTick cmra = (cameraangle)->null;
+		EventListenerRegistry.register(kb, ms, cmra);
+	}
 	
 	/**
 	 * Test constructor initializing keyboard, mouse and camera_angle

--- a/src/test/java/tasmod/virtual/VirtualInputTest.java
+++ b/src/test/java/tasmod/virtual/VirtualInputTest.java
@@ -310,35 +310,35 @@ class VirtualInputTest {
 
 		virtual.CAMERA_ANGLE.nextCameraTick();
 
-		Triple<Float, Float, Float> expected = Triple.of(0f, 0f, 0f);
+		Triple<Float, Float, Float> expected = Triple.of(0f, 180f, 0f);
 		Triple<Float, Float, Float> actual = virtual.CAMERA_ANGLE.getInterpolatedState(0f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(0f, 0f, 0f);
+		expected = Triple.of(0f, 180f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.1f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(10f, 10f, 0f);
+		expected = Triple.of(10f, 190f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.199f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(10f, 10f, 0f);
+		expected = Triple.of(10f, 190f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.2f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(20f, 20f, 0f);
+		expected = Triple.of(20f, 200f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.3f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(30f, 30f, 0f);
+		expected = Triple.of(30f, 210f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.4f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(40f, 40f, 0f);
+		expected = Triple.of(40f, 220f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.5f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(50f, 50f, 0f);
+		expected = Triple.of(50f, 230f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.6f, 0f, 0f, true);
 		assertEquals(expected, actual);
 	}

--- a/src/test/java/tasmod/virtual/VirtualInputTest.java
+++ b/src/test/java/tasmod/virtual/VirtualInputTest.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.minecrafttas.mctcommon.events.EventListenerRegistry;
@@ -340,29 +339,6 @@ class VirtualInputTest {
 
 		expected = Triple.of(50f, 230f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.6f, 0f, 0f, true);
-		assertEquals(expected, actual);
-	}
-
-	/**
-	 * Test interpolation but with playback running, but there are only 2 values
-	 */
-	@Test
-	@Disabled
-	void testInterpolationEnabledLegacy(){
-		VirtualInput virtual = new VirtualInput(LOGGER);
-
-		virtual.CAMERA_ANGLE.setCamera(0f, 0f);
-
-		virtual.CAMERA_ANGLE.updateNextCameraAngle(10f, 10f);
-
-		virtual.CAMERA_ANGLE.nextCameraTick();
-
-		Triple<Float, Float, Float> expected = Triple.of(0f, 0f, 0f);
-		Triple<Float, Float, Float> actual = virtual.CAMERA_ANGLE.getInterpolatedState(0f, 0f, 0f, true);
-		assertEquals(expected, actual);
-
-		expected = Triple.of(10f, 10f, 0f);
-		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.3f, 0f, 0f, true);
 		assertEquals(expected, actual);
 	}
 }

--- a/src/test/java/tasmod/virtual/VirtualInputTest.java
+++ b/src/test/java/tasmod/virtual/VirtualInputTest.java
@@ -314,7 +314,7 @@ class VirtualInputTest {
 		Triple<Float, Float, Float> actual = virtual.CAMERA_ANGLE.getInterpolatedState(0f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(10f, 10f, 0f);
+		expected = Triple.of(0f, 0f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.1f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
@@ -322,23 +322,23 @@ class VirtualInputTest {
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.199f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(20f, 20f, 0f);
+		expected = Triple.of(10f, 10f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.2f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(30f, 30f, 0f);
+		expected = Triple.of(20f, 20f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.3f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(40f, 40f, 0f);
+		expected = Triple.of(30f, 30f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.4f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(50f, 50f, 0f);
+		expected = Triple.of(40f, 40f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.5f, 0f, 0f, true);
 		assertEquals(expected, actual);
 
-		expected = Triple.of(60f, 60f, 0f);
+		expected = Triple.of(50f, 50f, 0f);
 		actual = virtual.CAMERA_ANGLE.getInterpolatedState(0.6f, 0f, 0f, true);
 		assertEquals(expected, actual);
 	}

--- a/src/test/java/tasmod/virtual/VirtualKeyboardTest.java
+++ b/src/test/java/tasmod/virtual/VirtualKeyboardTest.java
@@ -220,10 +220,36 @@ class VirtualKeyboardTest {
     }
 
     /**
-     * Test copy from method
+     * Test moveFrom method
      */
     @Test
-    void testCopyFrom(){
+    void testMoveFrom(){
+    	VirtualKeyboard moveFrom = new VirtualKeyboard();
+    	VirtualKeyboard actual = new VirtualKeyboard();
+    	
+    	moveFrom.update(VirtualKey.W.getKeycode(), true, 'w');
+    	moveFrom.update(VirtualKey.A.getKeycode(), true, 'a');
+    	
+    	VirtualKeyboard expected = moveFrom.clone();
+    	
+    	actual.update(VirtualKey.S.getKeycode(), true, 's');
+    	actual.update(VirtualKey.D.getKeycode(), true, 'd');
+
+    	actual.moveFrom(null);
+        actual.moveFrom(moveFrom);
+
+        assertIterableEquals(expected.getPressedKeys(), actual.getPressedKeys());
+        assertIterableEquals(expected.getCharList(), actual.getCharList());
+
+        assertTrue(moveFrom.getSubticks().isEmpty());
+        assertTrue(moveFrom.getCharList().isEmpty());
+    }
+
+    /**
+     * Test copyFrom method
+     */
+    @Test
+    void testCopyFrom() {
     	VirtualKeyboard copyFrom = new VirtualKeyboard();
     	VirtualKeyboard actual = new VirtualKeyboard();
     	
@@ -235,15 +261,16 @@ class VirtualKeyboardTest {
     	actual.update(VirtualKey.S.getKeycode(), true, 's');
     	actual.update(VirtualKey.D.getKeycode(), true, 'd');
 
+    	actual.copyFrom(null);
         actual.copyFrom(copyFrom);
 
         assertIterableEquals(expected.getPressedKeys(), actual.getPressedKeys());
         assertIterableEquals(expected.getCharList(), actual.getCharList());
 
-        assertTrue(copyFrom.getSubticks().isEmpty());
-        assertTrue(copyFrom.getCharList().isEmpty());
+        assertFalse(copyFrom.getSubticks().isEmpty());
+        assertFalse(copyFrom.getCharList().isEmpty());
     }
-
+    
     /**
      * Test subtick list being filled via update
      */

--- a/src/test/java/tasmod/virtual/VirtualKeyboardTest.java
+++ b/src/test/java/tasmod/virtual/VirtualKeyboardTest.java
@@ -201,10 +201,10 @@ class VirtualKeyboardTest {
     }
 
     /**
-     * Test cloning the keyboard
+     * Test shallow cloning the keyboard
      */
     @Test
-    void testClone() {
+    void testShallowClone() {
         Set<Integer> testKeycodeSet = new HashSet<>();
         testKeycodeSet.add(VirtualKey.W.getKeycode());
         testKeycodeSet.add(VirtualKey.S.getKeycode());
@@ -214,10 +214,12 @@ class VirtualKeyboardTest {
         testCharList.add('s');
 
         VirtualKeyboard actual = new VirtualKeyboard(testKeycodeSet, testCharList);
-        VirtualKeyboard test2 = actual.clone();
+        VirtualKeyboard test2 = actual.shallowClone();
         
         assertEquals(actual, test2);
     }
+    
+    //TODO DeepClone
 
     /**
      * Test moveFrom method

--- a/src/test/java/tasmod/virtual/VirtualKeyboardTest.java
+++ b/src/test/java/tasmod/virtual/VirtualKeyboardTest.java
@@ -213,13 +213,26 @@ class VirtualKeyboardTest {
         testCharList.add('w');
         testCharList.add('s');
 
-        VirtualKeyboard actual = new VirtualKeyboard(testKeycodeSet, testCharList);
-        VirtualKeyboard test2 = actual.shallowClone();
+        VirtualKeyboard expected = new VirtualKeyboard(testKeycodeSet, testCharList);
+        VirtualKeyboard actual = expected.shallowClone();
         
-        assertEquals(actual, test2);
+        assertEquals(expected, actual);
     }
-    
-    //TODO DeepClone
+
+	/**
+	 * Test deep cloning the keyboard
+	 */
+	@Test
+	void testDeepClone() {
+		VirtualKeyboard expected = new VirtualKeyboard();
+		expected.update(VirtualKey.W, true, 'w');
+		expected.update(VirtualKey.S, true, 's');
+
+		VirtualKeyboard actual = expected.clone();
+
+		assertEquals(expected, actual);
+		assertIterableEquals(expected.getSubticks(), actual.getSubticks());
+	}
 
     /**
      * Test moveFrom method

--- a/src/test/java/tasmod/virtual/VirtualMouseTest.java
+++ b/src/test/java/tasmod/virtual/VirtualMouseTest.java
@@ -192,6 +192,37 @@ class VirtualMouseTest {
 	}
 
 	/**
+	 * Test moveFrom method
+	 */
+	@Test
+	void testMoveFrom() {
+		VirtualMouse moveFrom = new VirtualMouse();
+		VirtualMouse actual = new VirtualMouse();
+
+		moveFrom.update(VirtualKey.LC.getKeycode(), true, 0, 0, 0);
+		moveFrom.update(VirtualKey.MOUSEMOVED.getKeycode(), false, 120, 10, 20);
+
+		VirtualMouse expected = moveFrom.clone();
+
+		actual.update(VirtualKey.MBUTTON12.getKeycode(), true, 0,0,0);
+		actual.update(VirtualKey.MOUSEMOVED.getKeycode(), true, -120, -10, -10);
+
+		actual.moveFrom(null);
+		
+		actual.moveFrom(moveFrom);
+
+		assertIterableEquals(expected.getPressedKeys(), actual.getPressedKeys());
+		assertEquals(expected.getScrollWheel(), actual.getScrollWheel());
+		assertEquals(expected.getCursorX(), actual.getCursorX());
+		assertEquals(expected.getCursorY(), actual.getCursorY());
+
+		assertTrue(moveFrom.getSubticks().isEmpty());
+		assertEquals(0, moveFrom.getScrollWheel());
+		assertEquals(0, moveFrom.getCursorX());
+		assertEquals(0, moveFrom.getCursorY());
+	}
+	
+	/**
 	 * Test copyFrom method
 	 */
 	@Test
@@ -207,6 +238,8 @@ class VirtualMouseTest {
 		actual.update(VirtualKey.MBUTTON12.getKeycode(), true, 0,0,0);
 		actual.update(VirtualKey.MOUSEMOVED.getKeycode(), true, -120, -10, -10);
 
+		actual.copyFrom(null);
+		
 		actual.copyFrom(copyFrom);
 
 		assertIterableEquals(expected.getPressedKeys(), actual.getPressedKeys());
@@ -214,10 +247,10 @@ class VirtualMouseTest {
 		assertEquals(expected.getCursorX(), actual.getCursorX());
 		assertEquals(expected.getCursorY(), actual.getCursorY());
 
-		assertTrue(copyFrom.getSubticks().isEmpty());
-		assertEquals(0, copyFrom.getScrollWheel());
-		assertEquals(0, copyFrom.getCursorX());
-		assertEquals(0, copyFrom.getCursorY());
+		assertFalse(copyFrom.getSubticks().isEmpty());
+		assertEquals(120, copyFrom.getScrollWheel());
+		assertEquals(10, copyFrom.getCursorX());
+		assertEquals(20, copyFrom.getCursorY());
 	}
 
 	/**

--- a/src/test/java/tasmod/virtual/VirtualMouseTest.java
+++ b/src/test/java/tasmod/virtual/VirtualMouseTest.java
@@ -22,7 +22,7 @@ import com.minecrafttas.tasmod.virtual.VirtualKey;
 import com.minecrafttas.tasmod.virtual.event.VirtualMouseEvent;
 
 class VirtualMouseTest {
-	
+
 	/**
 	 * Test the empty constructor
 	 */
@@ -35,42 +35,42 @@ class VirtualMouseTest {
 		assertEquals(0, actual.getCursorY());
 		assertTrue(actual.isParent());
 	}
-	
+
 	/**
 	 * Test constructor with premade keycode sets
 	 */
 	@Test
 	void testSubtickConstructor() {
-        Set<Integer> expected = new HashSet<>();
-        expected.add(VirtualKey.LC.getKeycode());
-        expected.add(VirtualKey.RC.getKeycode());
+		Set<Integer> expected = new HashSet<>();
+		expected.add(VirtualKey.LC.getKeycode());
+		expected.add(VirtualKey.RC.getKeycode());
 
-        VirtualMouse actual = new VirtualMouse(expected, -15, 0, 2);
+		VirtualMouse actual = new VirtualMouse(expected, -15, 0, 2);
 
-        assertIterableEquals(expected, actual.getPressedKeys());
-        assertEquals(-15, actual.getScrollWheel());
-        assertEquals(0, actual.getCursorX());
-        assertEquals(2, actual.getCursorY());
-        assertFalse(actual.isParent());
+		assertIterableEquals(expected, actual.getPressedKeys());
+		assertEquals(-15, actual.getScrollWheel());
+		assertEquals(0, actual.getCursorX());
+		assertEquals(2, actual.getCursorY());
+		assertFalse(actual.isParent());
 	}
-	
-    /**
-     * Test setting the keycodes via setPressed to "pressed"
-     */
-    @Test
-    void testSetPressedByKeycode(){
-        VirtualMouse actual = new VirtualMouse();
-        actual.setPressed(VirtualKey.LC.getKeycode(), true);
 
-        assertIterableEquals(Arrays.asList(VirtualKey.LC.getKeycode()), actual.getPressedKeys());
-        assertTrue(actual.isParent());
-    }
+	/**
+	 * Test setting the keycodes via setPressed to "pressed"
+	 */
+	@Test
+	void testSetPressedByKeycode() {
+		VirtualMouse actual = new VirtualMouse();
+		actual.setPressed(VirtualKey.LC.getKeycode(), true);
+
+		assertIterableEquals(Arrays.asList(VirtualKey.LC.getKeycode()), actual.getPressedKeys());
+		assertTrue(actual.isParent());
+	}
 
 	/**
 	 * Test setting the keynames via setPressed to "pressed"
 	 */
 	@Test
-	void testSetPressedByKeyname(){
+	void testSetPressedByKeyname() {
 		VirtualMouse actual = new VirtualMouse();
 		actual.setPressed("LC", true);
 
@@ -82,7 +82,7 @@ class VirtualMouseTest {
 	 * Test setting the keycodes via setPressed to "unpressed"
 	 */
 	@Test
-	void testSetUnPressedByKeycode(){
+	void testSetUnPressedByKeycode() {
 		Set<Integer> testKeycodeSet = new HashSet<>();
 		testKeycodeSet.add(VirtualKey.LC.getKeycode());
 		testKeycodeSet.add(VirtualKey.MBUTTON9.getKeycode());
@@ -96,7 +96,7 @@ class VirtualMouseTest {
 	 * Test setting the keynames via setPressed to "unpressed"
 	 */
 	@Test
-	void testSetUnPressedByKeyname(){
+	void testSetUnPressedByKeyname() {
 		Set<Integer> testKeycodeSet = new HashSet<>();
 		testKeycodeSet.add(VirtualKey.LC.getKeycode());
 		testKeycodeSet.add(VirtualKey.MBUTTON9.getKeycode());
@@ -110,7 +110,7 @@ class VirtualMouseTest {
 	 * Test the toString method <em>without</em> subticks
 	 */
 	@Test
-	void testToString(){
+	void testToString() {
 		Set<Integer> testKeycodeSet = new LinkedHashSet<>();
 		testKeycodeSet.add(VirtualKey.LC.getKeycode());
 		testKeycodeSet.add(VirtualKey.MC.getKeycode());
@@ -124,7 +124,7 @@ class VirtualMouseTest {
 	 * Test the toString method <em>with</em> subticks
 	 */
 	@Test
-	void testToStringSubtick(){
+	void testToStringSubtick() {
 		VirtualMouse actual = new VirtualMouse();
 		actual.update(VirtualKey.LC.getKeycode(), true, 10, 100, 120);
 		actual.update(VirtualKey.MC.getKeycode(), true, 0, 12, 3);
@@ -140,7 +140,6 @@ class VirtualMouseTest {
 		Set<Integer> testKeycodeSet = new HashSet<>();
 		testKeycodeSet.add(VirtualKey.W.getKeycode());
 		testKeycodeSet.add(VirtualKey.S.getKeycode());
-
 
 		VirtualMouse actual = new VirtualMouse(testKeycodeSet, -15, 129, 340);
 		VirtualMouse actual2 = new VirtualMouse(testKeycodeSet, -15, 129, 340);
@@ -161,8 +160,6 @@ class VirtualMouseTest {
 		Set<Integer> testKeycodeSet2 = new HashSet<>();
 		testKeycodeSet.add(VirtualKey.RC.getKeycode());
 		VirtualMouse test2 = new VirtualMouse(testKeycodeSet2, -15, 1, 1);
-
-
 
 		VirtualMouse test3 = new VirtualMouse(testKeycodeSet, -16, 1, 1);
 
@@ -190,8 +187,21 @@ class VirtualMouseTest {
 
 		assertEquals(actual, test2);
 	}
-	
-    //TODO DeepClone
+
+	/**
+	 * Test deep cloning the mouse
+	 */
+	@Test
+	void testDeepClone() {
+		VirtualMouse expected = new VirtualMouse();
+		expected.update(VirtualKey.LC, true, 15, 0, 0);
+		expected.update(VirtualKey.MOUSEMOVED, true, 0, 0, 0);
+
+		VirtualMouse actual = expected.clone();
+
+		assertEquals(expected, actual);
+		assertIterableEquals(expected.getSubticks(), actual.getSubticks());
+	}
 
 	/**
 	 * Test moveFrom method
@@ -206,11 +216,11 @@ class VirtualMouseTest {
 
 		VirtualMouse expected = moveFrom.clone();
 
-		actual.update(VirtualKey.MBUTTON12.getKeycode(), true, 0,0,0);
+		actual.update(VirtualKey.MBUTTON12.getKeycode(), true, 0, 0, 0);
 		actual.update(VirtualKey.MOUSEMOVED.getKeycode(), true, -120, -10, -10);
 
 		actual.moveFrom(null);
-		
+
 		actual.moveFrom(moveFrom);
 
 		assertIterableEquals(expected.getPressedKeys(), actual.getPressedKeys());
@@ -223,7 +233,7 @@ class VirtualMouseTest {
 		assertEquals(0, moveFrom.getCursorX());
 		assertEquals(0, moveFrom.getCursorY());
 	}
-	
+
 	/**
 	 * Test copyFrom method
 	 */
@@ -237,11 +247,11 @@ class VirtualMouseTest {
 
 		VirtualMouse expected = copyFrom.clone();
 
-		actual.update(VirtualKey.MBUTTON12.getKeycode(), true, 0,0,0);
+		actual.update(VirtualKey.MBUTTON12.getKeycode(), true, 0, 0, 0);
 		actual.update(VirtualKey.MOUSEMOVED.getKeycode(), true, -120, -10, -10);
 
 		actual.copyFrom(null);
-		
+
 		actual.copyFrom(copyFrom);
 
 		assertIterableEquals(expected.getPressedKeys(), actual.getPressedKeys());
@@ -259,7 +269,7 @@ class VirtualMouseTest {
 	 * Test subtick list being filled via update
 	 */
 	@Test
-	void testUpdate(){
+	void testUpdate() {
 		VirtualMouse actual = new VirtualMouse();
 		actual.update(VirtualKey.LC.getKeycode(), true, -30, 118, 42);
 		actual.update(VirtualKey.MOUSEMOVED.getKeycode(), false, 0, 23, 144);
@@ -270,154 +280,149 @@ class VirtualMouseTest {
 
 		assertIterableEquals(expected, actual.getAll());
 	}
-	
-    /**
-     * Tests getDifference
-     */
-    @Test
-    void testGetDifference(){
-        VirtualMouse test = new VirtualMouse(new HashSet<>(Arrays.asList(VirtualKey.LC.getKeycode())), 15, 0, 0);
-        VirtualMouse test2 = new VirtualMouse(new HashSet<>(Arrays.asList(VirtualKey.LC.getKeycode(), VirtualKey.RC.getKeycode())), 30, 1, 2);
-        Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
-        test.getDifference(test2, actual);
-        Queue<VirtualMouseEvent> expected = new ConcurrentLinkedQueue<>(Arrays.asList(new VirtualMouseEvent(VirtualKey.RC.getKeycode(), true, 30, 1, 2)));
 
-        assertIterableEquals(expected, actual);
-    }
-    
-    /**
-     * Tests generating virtual events going from an unpressed mouse to a pressed mouse state
-     */
-    @Test
-    void testGetVirtualEventsPress() {
-    	VirtualMouse unpressed = new VirtualMouse();
-    	
-    	VirtualMouse pressed = new VirtualMouse();
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
-    	
-    	// Load actual with the events
-    	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
-    	unpressed.getVirtualEvents(pressed, actual);
-    	
-    	// Load expected
-    	List<VirtualMouseEvent> expected = Arrays.asList(new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 15, 10, 12));
-    	
-    	assertIterableEquals(expected, actual);
-    }
-    
-    /**
-     * Tests generating virtual events going from a pressed mouse to an unpressed mouse state
-     */
-    @Test
-    void testGetVirtualEventsUnpress() {
-    	VirtualMouse unpressed = new VirtualMouse();
-    	
-    	VirtualMouse pressed = new VirtualMouse();
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
-    	
-    	// Load actual with the events
-    	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
-    	pressed.getVirtualEvents(unpressed, actual);
-    	
-    	// Load expected
-    	List<VirtualMouseEvent> expected = Arrays.asList(new VirtualMouseEvent(VirtualKey.LC.getKeycode(), false, 0, 0, 0));
-    	
-    	assertIterableEquals(expected, actual);
-    }
-    
-    /**
-     * Tests 2 updates having the same value and the scroll wheel is 0. Should return no additional button events
-     */
-    @Test
-    void testSameUpdate() {
-    	VirtualMouse unpressed = new VirtualMouse();
-    	
-    	VirtualMouse pressed = new VirtualMouse();
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
-    	
-    	// Load actual with the events
-    	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
-    	unpressed.getVirtualEvents(pressed, actual);
-    	
-    	// Load expected
-    	List<VirtualMouseEvent> expected = Arrays.asList(
-    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 0, 10, 12) // Should only have one keyboard event
-    			); 
-    	
-    	assertIterableEquals(expected, actual);
-    }
-    
-    
-    /**
-     * Tests 2 updates having the same pressed keys, but scrollWheel != 0
-     */
-    @Test
-    void testScrollWheelDifferent() {
-    	VirtualMouse unpressed = new VirtualMouse();
-    	
-    	VirtualMouse pressed = new VirtualMouse();
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
-    	
-    	// Load actual with the events
-    	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
-    	unpressed.getVirtualEvents(pressed, actual);
-    	
-    	// Load expected
-    	List<VirtualMouseEvent> expected = Arrays.asList(
-    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 15, 10, 12),
-    			new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 15, 10, 12) // Adds an additional "MOUSEMOVED" event with the scroll wheel
-    			);
-    	
-    	assertIterableEquals(expected, actual);
-    }
-    
-    /**
-     * Tests 2 updates having the same pressed keys, but scrollWheel is different
-     */
-    @Test
-    void testCursorXDifferent() {
-    	VirtualMouse unpressed = new VirtualMouse();
-    	
-    	VirtualMouse pressed = new VirtualMouse();
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 11, 12);
-    	
-    	// Load actual with the events
-    	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
-    	unpressed.getVirtualEvents(pressed, actual);
-    	
-    	// Load expected
-    	List<VirtualMouseEvent> expected = Arrays.asList(
-    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 0, 10, 12),
-    			new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 0, 11, 12) // Adds an additional "MOUSEMOVED" event with the cursorX
-    			);
-    	
-    	assertIterableEquals(expected, actual);
-    }
-    
-    /**
-     * Tests 2 updates having the same pressed keys, but scrollWheel is different
-     */
-    @Test
-    void testCursorYDifferent() {
-    	VirtualMouse unpressed = new VirtualMouse();
-    	
-    	VirtualMouse pressed = new VirtualMouse();
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
-    	pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 120);
-    	
-    	// Load actual with the events
-    	Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
-    	unpressed.getVirtualEvents(pressed, actual);
-    	
-    	// Load expected
-    	List<VirtualMouseEvent> expected = Arrays.asList(
-    			new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 0, 10, 12),
-    			new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 0, 10, 120) // Adds an additional "MOUSEMOVED" event with the cursorY
-    			);
-    	
-    	assertIterableEquals(expected, actual);
-    }
+	/**
+	 * Tests getDifference
+	 */
+	@Test
+	void testGetDifference() {
+		VirtualMouse test = new VirtualMouse(new HashSet<>(Arrays.asList(VirtualKey.LC.getKeycode())), 15, 0, 0);
+		VirtualMouse test2 = new VirtualMouse(new HashSet<>(Arrays.asList(VirtualKey.LC.getKeycode(), VirtualKey.RC.getKeycode())), 30, 1, 2);
+		Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
+		test.getDifference(test2, actual);
+		Queue<VirtualMouseEvent> expected = new ConcurrentLinkedQueue<>(Arrays.asList(new VirtualMouseEvent(VirtualKey.RC.getKeycode(), true, 30, 1, 2)));
+
+		assertIterableEquals(expected, actual);
+	}
+
+	/**
+	 * Tests generating virtual events going from an unpressed mouse to a pressed
+	 * mouse state
+	 */
+	@Test
+	void testGetVirtualEventsPress() {
+		VirtualMouse unpressed = new VirtualMouse();
+
+		VirtualMouse pressed = new VirtualMouse();
+		pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
+
+		// Load actual with the events
+		Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
+		unpressed.getVirtualEvents(pressed, actual);
+
+		// Load expected
+		List<VirtualMouseEvent> expected = Arrays.asList(new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 15, 10, 12));
+
+		assertIterableEquals(expected, actual);
+	}
+
+	/**
+	 * Tests generating virtual events going from a pressed mouse to an unpressed
+	 * mouse state
+	 */
+	@Test
+	void testGetVirtualEventsUnpress() {
+		VirtualMouse unpressed = new VirtualMouse();
+
+		VirtualMouse pressed = new VirtualMouse();
+		pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
+
+		// Load actual with the events
+		Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
+		pressed.getVirtualEvents(unpressed, actual);
+
+		// Load expected
+		List<VirtualMouseEvent> expected = Arrays.asList(new VirtualMouseEvent(VirtualKey.LC.getKeycode(), false, 0, 0, 0));
+
+		assertIterableEquals(expected, actual);
+	}
+
+	/**
+	 * Tests 2 updates having the same value and the scroll wheel is 0. Should
+	 * return no additional button events
+	 */
+	@Test
+	void testSameUpdate() {
+		VirtualMouse unpressed = new VirtualMouse();
+
+		VirtualMouse pressed = new VirtualMouse();
+		pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
+		pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
+
+		// Load actual with the events
+		Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
+		unpressed.getVirtualEvents(pressed, actual);
+
+		// Load expected
+		List<VirtualMouseEvent> expected = Arrays.asList(new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 0, 10, 12) // Should only have one keyboard event
+		);
+
+		assertIterableEquals(expected, actual);
+	}
+
+	/**
+	 * Tests 2 updates having the same pressed keys, but scrollWheel != 0
+	 */
+	@Test
+	void testScrollWheelDifferent() {
+		VirtualMouse unpressed = new VirtualMouse();
+
+		VirtualMouse pressed = new VirtualMouse();
+		pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
+		pressed.update(VirtualKey.LC.getKeycode(), true, 15, 10, 12);
+
+		// Load actual with the events
+		Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
+		unpressed.getVirtualEvents(pressed, actual);
+
+		// Load expected
+		List<VirtualMouseEvent> expected = Arrays.asList(new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 15, 10, 12), new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 15, 10, 12) // Adds an additional "MOUSEMOVED" event with the scroll wheel
+		);
+
+		assertIterableEquals(expected, actual);
+	}
+
+	/**
+	 * Tests 2 updates having the same pressed keys, but scrollWheel is different
+	 */
+	@Test
+	void testCursorXDifferent() {
+		VirtualMouse unpressed = new VirtualMouse();
+
+		VirtualMouse pressed = new VirtualMouse();
+		pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
+		pressed.update(VirtualKey.LC.getKeycode(), true, 0, 11, 12);
+
+		// Load actual with the events
+		Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
+		unpressed.getVirtualEvents(pressed, actual);
+
+		// Load expected
+		List<VirtualMouseEvent> expected = Arrays.asList(new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 0, 10, 12), new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 0, 11, 12) // Adds an additional "MOUSEMOVED" event with the cursorX
+		);
+
+		assertIterableEquals(expected, actual);
+	}
+
+	/**
+	 * Tests 2 updates having the same pressed keys, but scrollWheel is different
+	 */
+	@Test
+	void testCursorYDifferent() {
+		VirtualMouse unpressed = new VirtualMouse();
+
+		VirtualMouse pressed = new VirtualMouse();
+		pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 12);
+		pressed.update(VirtualKey.LC.getKeycode(), true, 0, 10, 120);
+
+		// Load actual with the events
+		Queue<VirtualMouseEvent> actual = new ConcurrentLinkedQueue<>();
+		unpressed.getVirtualEvents(pressed, actual);
+
+		// Load expected
+		List<VirtualMouseEvent> expected = Arrays.asList(new VirtualMouseEvent(VirtualKey.LC.getKeycode(), true, 0, 10, 12), new VirtualMouseEvent(VirtualKey.MOUSEMOVED.getKeycode(), false, 0, 10, 120) // Adds an additional "MOUSEMOVED" event with the cursorY
+		);
+
+		assertIterableEquals(expected, actual);
+	}
 }

--- a/src/test/java/tasmod/virtual/VirtualMouseTest.java
+++ b/src/test/java/tasmod/virtual/VirtualMouseTest.java
@@ -230,8 +230,8 @@ class VirtualMouseTest {
 
 		assertTrue(moveFrom.getSubticks().isEmpty());
 		assertEquals(0, moveFrom.getScrollWheel());
-		assertEquals(0, moveFrom.getCursorX());
-		assertEquals(0, moveFrom.getCursorY());
+		assertEquals(10, moveFrom.getCursorX());
+		assertEquals(20, moveFrom.getCursorY());
 	}
 
 	/**

--- a/src/test/java/tasmod/virtual/VirtualMouseTest.java
+++ b/src/test/java/tasmod/virtual/VirtualMouseTest.java
@@ -177,19 +177,21 @@ class VirtualMouseTest {
 	}
 
 	/**
-	 * Test cloning the mouse
+	 * Test shallow cloning the mouse
 	 */
 	@Test
-	void testClone() {
+	void testShallowClone() {
 		Set<Integer> testKeycodeSet = new HashSet<>();
 		testKeycodeSet.add(VirtualKey.LC.getKeycode());
 		testKeycodeSet.add(VirtualKey.MC.getKeycode());
 
 		VirtualMouse actual = new VirtualMouse(testKeycodeSet, 10, 3, 2);
-		VirtualMouse test2 = actual.clone();
+		VirtualMouse test2 = actual.shallowClone();
 
 		assertEquals(actual, test2);
 	}
+	
+    //TODO DeepClone
 
 	/**
 	 * Test moveFrom method


### PR DESCRIPTION
Continuation of #179

# Changes
## PlaybackController
The main focus of this PR was to reduce complexity in the PlaybackController, the main class for starting/stopping recordings/playbacks.

Up to now, everything playback related was added to the controller, without any consideration for architecture.

Hooks into the VirtualInput-System are now added via EventVirtualKeyboardTick, EventVirtualMouseTick, EventVirtualCameraAngleTick.  
Any future TASmod extensions can use these too by implementing `EventVirtualKeyboardTick` in your class and registering it via `EventListenerRegistry.register(YourClass)`

## PlaybackMetadata
The first lines of the TASfile contain metadata that is used for storing playback specific configuration.  
In Alpha9 this metadata consisted of:
- Author of the TAS
- Title of the TAS
- Playtime / Runtime of the TAS
- Rerecords
- Starting location of the TAS
- Starting seed of the TAS

All of these (except starting seed, which is due in #190) have now been rewritten in the form of PlaybackMetadata.

```java
public class CustomMetadataExtension implements PlaybackMetadataExtension {
	@Override
	public String getExtensionName() {
		return "Name";
	}

	@Override
	public void onCreate() {
		// Unused atm
	}

	@Override
	public PlaybackMetadata onStore() {
		PlaybackMetadata metadata = new PlaybackMetadata(this);
		metadata.setValue("Test", "Test")
		return metadata;
	}

	@Override
	public void onLoad(PlaybackMetadata metadata) {
		System.out.printLn(metadata.getValue("Test"));
	}

	@Override
	public void onClear() {
		// E.g. When /clearinputs is run
	}
}
```

After registering this class under `PlaybackMetadataRegistry`, any time you run `/saveTAS` or `/loadTAS`,  
your custom metadata is automatically stored in the TASFile in the first lines. (At the time of writing, serialization is not implemented, this is my next task)

Such a system will also be used for making extensions to a line in the TASFile itself.

# Fixes
Fixed a load of interpolation issues introduced in the #179 PR.

# TODO
- [x] Why only focus on one, when you can have both! Rename `copyFrom` to `moveFrom` and write `copyFrom` that actually copies the methods!
- New PlaybackMetadata
	- [x] Run author etc via PM
	- [x] Run start location via PM
- [x] Add event to enable playuntil
- [x] Add event to trigger printing the author name at the start of the TAS