### PR TITLE
[PlaybackSersialiser] Fix Filethread always appending instead of truncating the output file

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -36,7 +36,6 @@ import com.minecrafttas.tasmod.registries.TASmodConfig;
 import com.minecrafttas.tasmod.registries.TASmodKeybinds;
 import com.minecrafttas.tasmod.registries.TASmodPackets;
 import com.minecrafttas.tasmod.savestates.SavestateHandlerClient;
-import com.minecrafttas.tasmod.savestates.handlers.SavestatePlayerHandler;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerClient;
 import com.minecrafttas.tasmod.ticksync.TickSyncClient;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
@@ -165,7 +164,6 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		PacketHandlerRegistry.register(ticksyncClient);
 		PacketHandlerRegistry.register(tickratechanger);
 		PacketHandlerRegistry.register(savestateHandlerClient);
-		PacketHandlerRegistry.register(new SavestatePlayerHandler(null));
 	}
 
 	private void registerEventListeners() {

--- a/src/main/java/com/minecrafttas/tasmod/util/FileThread.java
+++ b/src/main/java/com/minecrafttas/tasmod/util/FileThread.java
@@ -24,7 +24,7 @@ public class FileThread extends Thread {
 	private final List<String> output = new ArrayList<>();
 
 	public FileThread(Path fileLocation, boolean append) throws IOException {
-		OutputStream outStream = Files.newOutputStream(fileLocation, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+		OutputStream outStream = Files.newOutputStream(fileLocation, StandardOpenOption.CREATE, append ? StandardOpenOption.APPEND : StandardOpenOption.TRUNCATE_EXISTING);
 		stream = new PrintWriter(new OutputStreamWriter(outStream, StandardCharsets.UTF_8));
 	}
 


### PR DESCRIPTION
A bit of a hotfix to my previous PR, where I just switched to Paths without knowing what this "append" thing means apparently