### PR TITLE
[VirtualInput] Fix subticks not being recorded in GuiScreens

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/mixin/playbackhooks/MixinGuiScreen.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/playbackhooks/MixinGuiScreen.java
@@ -1,6 +1,5 @@
 package com.minecrafttas.tasmod.mixin.playbackhooks;
 
-import com.minecrafttas.tasmod.virtual.VirtualInput;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.minecrafttas.tasmod.TASmodClient;
 import com.minecrafttas.tasmod.util.Ducks.GuiScreenDuck;
+import com.minecrafttas.tasmod.virtual.VirtualInput;
 import com.minecrafttas.tasmod.virtual.event.VirtualKeyboardEvent;
 
 import net.minecraft.client.Minecraft;
@@ -39,7 +39,6 @@ public class MixinGuiScreen implements GuiScreenDuck {
 		return TASmodClient.virtual.KEYBOARD.nextKeyboardSubtick();
 	}
 
-	
 	@Redirect(method = "handleKeyboardInput", at = @At(value = "INVOKE", target = "Lorg/lwjgl/input/Keyboard;getEventCharacter()C", remap = false))
 	public char redirectGetEventCharacter() {
 		return TASmodClient.virtual.KEYBOARD.getEventKeyboardCharacter();

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualPeripheral.java
@@ -150,7 +150,7 @@ public abstract class VirtualPeripheral<T extends VirtualPeripheral<T>> extends 
 	protected void moveFrom(T peripheral) {
 		if (peripheral == null)
 			return;
-		copyFrom(peripheral);
+		deepCopyFrom(peripheral);
 		peripheral.subtickList.clear();
 		peripheral.resetFirstUpdate();
 	}


### PR DESCRIPTION
What a weird oversight

Up to now, subticks were not recorded in Gui screens.  
Reason was that nextTickKeyboard (and Mouse) is called twice when a GuiScreen is open.

nextTickKeyboard adds the current keyboard to the PlaybackController, where it will be recorded at the end of the tick,  
then clears the subticks of that keyboard.

By calling the method twice, a keyboard without subticks overwrites the keyboard in the PlaybackController, making it record a subtickless keyboard to the inputs.