### PR TITLE
[PlaybackController] Add playing back TASes even when game is unfocused

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/events/EventVirtualInput.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/EventVirtualInput.java
@@ -7,6 +7,8 @@ import com.minecrafttas.tasmod.virtual.VirtualInput.VirtualKeyboardInput;
 import com.minecrafttas.tasmod.virtual.VirtualInput.VirtualMouseInput;
 import com.minecrafttas.tasmod.virtual.VirtualKeyboard;
 import com.minecrafttas.tasmod.virtual.VirtualMouse;
+import com.minecrafttas.tasmod.virtual.event.VirtualKeyboardEvent;
+import com.minecrafttas.tasmod.virtual.event.VirtualMouseEvent;
 
 public interface EventVirtualInput {
 
@@ -65,4 +67,43 @@ public interface EventVirtualInput {
 		 */
 		public VirtualCameraAngle onVirtualCameraTick(VirtualCameraAngle vcamera);
 	}
+
+	/**
+	 * Fired when the {@link VirtualKeyboardInput#currentKeyboardEvent} is updated
+	 *
+	 * @see VirtualKeyboardInput#nextKeyboardSubtick()
+	 */
+	@FunctionalInterface
+	interface EventVirtualKeyboardSubtick extends EventBase {
+
+		/**
+		 * Fired when the {@link VirtualKeyboardInput#currentKeyboardEvent} is updated
+		 *
+		 * @param event The keyboard event (An input event, not an eventlistener event!)
+		 * @see VirtualKeyboardInput#nextKeyboardSubtick()
+		 */
+		public void onVirtualKeyboardSubtick(VirtualKeyboardEvent event);
+	}
+
+	/**
+	 * Fired when the {@link VirtualMouseInput#currentMouseEvent} is updated
+	 *
+	 * @see VirtualMouseInput#nextMouseSubtick()
+	 */
+	@FunctionalInterface
+	interface EventVirtualMouseSubtick extends EventBase {
+		/**
+		 * Fired when the {@link VirtualMouseInput#currentMouseEvent} is updated
+		 *
+		 * @param event The keyboard event (An input event, not an eventlistener event!)
+		 * @see VirtualMouseInput#nextMouseSubtick()
+		 */
+		public void onVirtualMouseSubtick(VirtualMouseEvent event);
+	}
+
+	// Doesn't exist yet... Maybe in the future?
+//	@FunctionalInterface
+//	interface EventVirtualCameraAngleSubtick extends EventBase {
+//		public void onVirtualCameraSubtick(boolean isPolled);
+//	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/fixes/MixinDragonFightManager.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/fixes/MixinDragonFightManager.java
@@ -10,24 +10,24 @@ import net.minecraft.world.end.DragonFightManager;
 
 @Mixin(DragonFightManager.class)
 public abstract class MixinDragonFightManager {
-	
+
 	@Shadow
-    public boolean scanForLegacyFight;
+	public boolean scanForLegacyFight;
 	@Shadow
-    public boolean previouslyKilled;
+	public boolean previouslyKilled;
 	private int ticks = 20;
-	
+
 	@Inject(at = @At("RETURN"), method = "<init>")
-	public void endInit(CallbackInfo ci) {
+	public void fixes_endInit(CallbackInfo ci) {
 		scanForLegacyFight = false;
 	}
-	
+
 	@Inject(at = @At("HEAD"), method = "tick")
-	public void injecttick(CallbackInfo ci) {
+	public void fixes_tick(CallbackInfo ci) {
 		ticks--;
 		if (ticks == 0 && previouslyKilled) {
 			scanForLegacyFight = true;
 		}
 	}
-	
+
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/fixes/MixinMinecraftFullscreen.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/fixes/MixinMinecraftFullscreen.java
@@ -13,13 +13,13 @@ import net.minecraft.client.settings.GameSettings;
 
 @Mixin(Minecraft.class)
 public class MixinMinecraftFullscreen {
-	
+
 	@Shadow
 	private GameSettings gameSettings;
 
 	@Inject(method = "toggleFullscreen", at = @At("RETURN"))
-	public void inject_toggleFullscreen(CallbackInfo ci) {
-		int keyF11=this.gameSettings.keyBindFullscreen.getKeyCode();
+	public void fixes_toggleFullscreen(CallbackInfo ci) {
+		int keyF11 = this.gameSettings.keyBindFullscreen.getKeyCode();
 		TASmodClient.virtual.KEYBOARD.updateNextKeyboard(keyF11, false, Character.MIN_VALUE);
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/fixes/MixinMouseHelper.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/fixes/MixinMouseHelper.java
@@ -1,0 +1,34 @@
+package com.minecrafttas.tasmod.mixin.fixes;
+
+import org.lwjgl.opengl.Display;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.minecrafttas.tasmod.TASmodClient;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.MouseHelper;
+
+/**
+ * Disables MouseCursor grabbing when playing back and pauseOnLostFocus is false
+ * 
+ * @author Scribble
+ */
+@Mixin(MouseHelper.class)
+public class MixinMouseHelper {
+	@Inject(method = "grabMouseCursor", at = @At(value = "HEAD"), cancellable = true)
+	private void fixes_grabMouseCursor(CallbackInfo ci) {
+		Minecraft mc = Minecraft.getMinecraft();
+		if (TASmodClient.controller.isPlayingback() && !mc.gameSettings.pauseOnLostFocus && !Display.isActive())
+			ci.cancel();
+	}
+
+	@Inject(method = "ungrabMouseCursor", at = @At(value = "HEAD"), cancellable = true)
+	private void fixes_ungrabMouseCursor(CallbackInfo ci) {
+		Minecraft mc = Minecraft.getMinecraft();
+		if (TASmodClient.controller.isPlayingback() && !mc.gameSettings.pauseOnLostFocus && !Display.isActive())
+			ci.cancel();
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/mixin/fixes/MixinNetworkManager.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/fixes/MixinNetworkManager.java
@@ -24,7 +24,7 @@ public class MixinNetworkManager {
 	 * @param manager
 	 */
 	@Redirect(method = "processReceivedPackets", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/ITickable;update()V"))
-	public void redirect_processReceivedPackets(ITickable manager) {
+	public void fixes_processReceivedPackets(ITickable manager) {
 		if (TASmod.tickratechanger.ticksPerSecond == 0) {
 			if (!(packetListener instanceof NetHandlerPlayServer) || TASmodClient.loadingScreenHandler.isLoading()) {
 				manager.update();

--- a/src/main/java/com/minecrafttas/tasmod/mixin/playbackhooks/MixinGuiScreen.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/playbackhooks/MixinGuiScreen.java
@@ -1,6 +1,5 @@
 package com.minecrafttas.tasmod.mixin.playbackhooks;
 
-import org.lwjgl.input.Mouse;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -64,9 +63,6 @@ public class MixinGuiScreen implements GuiScreenDuck {
 
 	@Redirect(method = "handleMouseInput", at = @At(value = "INVOKE", target = "Lorg/lwjgl/input/Mouse;getEventButtonState()Z", remap = false))
 	public boolean redirectGetEventButtonState() {
-		if (TASmodClient.controller.isPlayingback()) { // TODO replace with event
-			Mouse.setCursorPosition(rescaleX(TASmodClient.virtual.MOUSE.getEventCursorX()), rescaleY(TASmodClient.virtual.MOUSE.getEventCursorY()));
-		}
 		return TASmodClient.virtual.MOUSE.getEventMouseState();
 	}
 

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
+import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.Display;
 
 import com.dselent.bigarraylist.BigArrayList;
@@ -48,17 +49,21 @@ import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackSaveException;
 import com.minecrafttas.tasmod.playback.tasfile.flavor.SerialiserFlavorBase;
 import com.minecrafttas.tasmod.registries.TASmodConfig;
 import com.minecrafttas.tasmod.registries.TASmodPackets;
+import com.minecrafttas.tasmod.util.Ducks.GuiScreenDuck;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
+import com.minecrafttas.tasmod.util.PointerNormalizer;
 import com.minecrafttas.tasmod.util.Scheduler.Task;
 import com.minecrafttas.tasmod.virtual.VirtualCameraAngle;
 import com.minecrafttas.tasmod.virtual.VirtualInput;
 import com.minecrafttas.tasmod.virtual.VirtualInput.VirtualCameraAngleInput;
 import com.minecrafttas.tasmod.virtual.VirtualKeyboard;
 import com.minecrafttas.tasmod.virtual.VirtualMouse;
+import com.minecrafttas.tasmod.virtual.event.VirtualMouseEvent;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.GuiMainMenu;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
@@ -82,8 +87,20 @@ import net.minecraft.util.text.event.ClickEvent;
  * @author Scribble
  *
  */
-public class PlaybackControllerClient implements ClientPacketHandler, EventClientInit, EventVirtualInput.EventVirtualKeyboardTick, EventVirtualInput.EventVirtualMouseTick, EventVirtualInput.EventVirtualCameraAngleTick, EventClientTickPost {
-
+public class PlaybackControllerClient implements
+//@formatter:off
+	ClientPacketHandler,
+	
+	EventClientInit,
+	EventClientTickPost,
+	
+	EventVirtualInput.EventVirtualKeyboardTick,
+	EventVirtualInput.EventVirtualMouseTick,
+	EventVirtualInput.EventVirtualCameraAngleTick,
+	
+	EventVirtualInput.EventVirtualMouseSubtick
+	//@formatter:on
+{
 	private Logger logger = TASmod.LOGGER;
 
 	/**
@@ -380,6 +397,40 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventClien
 	}
 
 	/**
+	 * Updates the cursor location on screen
+	 */
+	@Override
+	public void onVirtualMouseSubtick(VirtualMouseEvent event) {
+		if (!isPlayingback() || event == null)
+			return;
+
+		Minecraft mc = Minecraft.getMinecraft();
+		if (!mc.gameSettings.pauseOnLostFocus && !Display.isActive()) // If pause on lost focus is on and the display is not active don't set the cursor position
+			return;
+
+		GuiScreen screen = mc.currentScreen;
+		if (screen == null)
+			return;
+
+		GuiScreenDuck duckedScreen = (GuiScreenDuck) mc.currentScreen;
+		//@formatter:off
+		Mouse.setCursorPosition(
+				duckedScreen.rescaleX(
+						PointerNormalizer.reapplyScalingX(
+								event.getCursorX()
+								)
+						),
+				duckedScreen.rescaleY(
+						PointerNormalizer.reapplyScalingY(
+								event.getCursorY()
+								)
+						
+						)
+				);
+		//@formatter:on
+	}
+
+	/**
 	 * Updates the input container.<br>
 	 * <br>
 	 * During a recording this adds the {@linkplain #keyboard}, {@linkplain #mouse}
@@ -431,9 +482,9 @@ public class PlaybackControllerClient implements ClientPacketHandler, EventClien
 	}
 
 	private void playbackNextTick() {
-
-		if (!Display.isActive()) { // Stops the playback when you tab out of minecraft, for once as a failsafe,
-									// secondly as potential exploit protection
+		Minecraft mc = Minecraft.getMinecraft();
+		if (!Display.isActive() && mc.gameSettings.pauseOnLostFocus) { // Stops the playback when you tab out of minecraft, for once as a failsafe,
+																		// secondly as potential exploit protection
 			LOGGER.info(LoggerMarkers.Playback, "Stopping a {} since the user tabbed out of the game", state);
 			setTASState(TASstate.NONE);
 		}

--- a/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
+++ b/src/main/java/com/minecrafttas/tasmod/virtual/VirtualInput.java
@@ -287,7 +287,9 @@ public class VirtualInput {
 		 * @return If a keyboard event is in {@link #keyboardEventQueue}
 		 */
 		public boolean nextKeyboardSubtick() {
-			return (currentKeyboardEvent = keyboardEventQueue.poll()) != null;
+			boolean isPolled = (currentKeyboardEvent = keyboardEventQueue.poll()) != null;
+			EventListenerRegistry.fireEvent(EventVirtualInput.EventVirtualKeyboardSubtick.class, currentKeyboardEvent);
+			return isPolled;
 		}
 
 		/**
@@ -447,7 +449,9 @@ public class VirtualInput {
 		 * @return If a mouse event is in {@link #mouseEventQueue}
 		 */
 		public boolean nextMouseSubtick() {
-			return (currentMouseEvent = mouseEventQueue.poll()) != null;
+			boolean isPolled = (currentMouseEvent = mouseEventQueue.poll()) != null;
+			EventListenerRegistry.fireEvent(EventVirtualInput.EventVirtualMouseSubtick.class, currentMouseEvent);
+			return isPolled;
 		}
 
 		/**

--- a/src/main/resources/tasmod.mixin.json
+++ b/src/main/resources/tasmod.mixin.json
@@ -64,6 +64,7 @@
 		
 		// Fixes
 		"fixes.MixinMinecraftFullscreen",
-		"fixes.MixinNetworkManager"
+		"fixes.MixinNetworkManager",
+		"fixes.MixinMouseHelper"
 	]
 }


### PR DESCRIPTION
Sometimes, you just want to tab out of the game, while a TAS is running. But this proved to be difficult, as the mouse is reset to the game window, whenever a gui is opened.

This change eliminates cursor setting when the following 3 conditions are met:
1. The game is currently playing back a TAS
2. The option "pauseOnLostFocus" is off (<kbd>F3</kbd>+<kbd>P</kbd>)
3. The game is tabbed out

There will be some visual glitches with items floating around, when the TAS picks them up in containers, but other than that, it will work...

- Closes #161 
- Add better cursor handling.
- Add VirtualInput.SubtickEvents