### PR TITLE
[FileCommands] Refactor, documentation and fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.legacyfabric:yarn:${project.minecraft_version}+build.mcp"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.12.2'
 }
 
 // task for downloading KillTheRng

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.legacyfabric:yarn:${project.minecraft_version}+build.mcp"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.12.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
 }
 
 // task for downloading KillTheRng

--- a/src/main/java/com/minecrafttas/tasmod/events/EventPlaybackClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/EventPlaybackClient.java
@@ -82,6 +82,6 @@ public interface EventPlaybackClient {
 		/**
 		 * Fired when a recording is cleared
 		 */
-		public void onClear();
+		public void onRecordingClear();
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommand.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommand.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.dselent.bigarraylist.BigArrayList;
@@ -13,6 +12,7 @@ import com.minecrafttas.mctcommon.file.AbstractDataFile;
 import com.minecrafttas.mctcommon.registry.Registerable;
 import com.minecrafttas.tasmod.TASmodClient;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
+import com.minecrafttas.tasmod.playback.tasfile.flavor.SerialiserFlavorBase;
 
 public class PlaybackFileCommand {
 
@@ -105,18 +105,18 @@ public class PlaybackFileCommand {
 		public void onPlayback(long tick, InputContainer inputContainer) {
 		};
 
-		public PlaybackFileCommandContainer onSerialiseInlineComment(long tick, InputContainer inputContainer) {
+		public SortedFileCommandContainer onSerialiseInlineComment(long tick, InputContainer inputContainer) {
 			return null;
 		}
 
-		public PlaybackFileCommandContainer onSerialiseEndlineComment(long currentTick, InputContainer inputContainer) {
+		public SortedFileCommandContainer onSerialiseEndlineComment(long currentTick, InputContainer inputContainer) {
 			return null;
 		}
 
-		public void onDeserialiseInlineComment(long tick, InputContainer container, PlaybackFileCommandContainer fileCommandContainer) {
+		public void onDeserialiseInlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
 		}
 
-		public void onDeserialiseEndlineComment(long tick, InputContainer container, PlaybackFileCommandContainer fileCommandContainer) {
+		public void onDeserialiseEndlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
 		}
 
 		public boolean isEnabled() {
@@ -137,43 +137,176 @@ public class PlaybackFileCommand {
 		}
 	}
 
-	public static class PlaybackFileCommandContainer extends LinkedHashMap<String, PlaybackFileCommandLine> {
+	/**
+	 * <p>List of FileCommands in one comment.
+	 * <p>This class is the same as <code>ArrayList&lt;PlaybackFileCommand&gt;</code>
+	 * <p>In a comment, you can have multiple file commands, hence a list is needed to store them all.
+	 * <h5>Example</h5>
+	 * <pre>
+	 * // $desyncMonitor(13, 0, 1, 1, 1, 1); $hud(true);
+	 * </pre>
+	 * <p>This would translate into an ArrayList like
+	 * <pre>
+	 * [$desyncMonitor(13, 0, 1, 1, 1, 1);, $hud(true);]
+	 * </pre>
+	 * 
+	 * <p>Used in {@link UnsortedFileCommandContainer} for serialisation and deserialisation
+	 * <p>Although this class is the same as {@link FileCommandsInTickList}, their use case differs slightly,<br>
+	 * hence I created 2 classes for the sake of clarity.
+	 * 
+	 * @author Scribble
+	 */
+	public static class FileCommandsInCommentList extends ArrayList<PlaybackFileCommand> {
+	}
 
-		public PlaybackFileCommandContainer() {
-		}
+	/**
+	 * <p>An ArrayList for storing {@link FileCommandsInCommentList} sorted by order of appearence in the {@link InputContainer}
+	 * <p>This stands in contrast to the {@link SortedFileCommandContainer}, which can be obtained by calling {@link UnsortedFileCommandContainer#sort() sort()}
+	 * <p>This is technically a 2 dimensional List for storing file commands for multiple comments, where {@link FileCommandsInCommentList} is one row of file commands
+	 * <p>Used in {@link SerialiserFlavorBase} as this format makes it easier to deal with serialisation and deserialisation
+	 * <h5>Example</h5>
+	 * <pre>
+	 * // $desyncMonitor(13, 0, 1, 1, 1, 1); $hud(true);
+	 * // $desyncMonitor(16, 3, 1, 1, 1, 1); $hud(false);
+	 * // $label(Test); $hud(false);
+	 * </pre>
+	 * <p>This would translate into an ArrayList like
+	 * <pre>
+	 * [
+	 * 	[$desyncMonitor(13, 0, 1, 1, 1, 1);, $hud(true);]	&lt;- One {@link FileCommandsInCommentList}
+	 * 	[$desyncMonitor(16, 3, 1, 1, 1, 1);, $hud(false);]
+	 * 	[$label(Test);, $hud(false);]
+	 * ]
+	 * </pre>
+	 * @author Scribble
+	 * @see SortedFileCommandContainer
+	 */
+	public static class UnsortedFileCommandContainer extends ArrayList<FileCommandsInCommentList> {
 
-		public PlaybackFileCommandContainer(List<List<PlaybackFileCommand>> list) {
-			for (List<PlaybackFileCommand> lists : list) {
-				if (lists != null) {
-					for (PlaybackFileCommand command : lists) {
-						this.put(command.getName(), new PlaybackFileCommandLine());
+		/**
+		 * <p>Sorts this array list by the file command names
+		 * @return A {@link SortedFileCommandContainer}
+		 */
+		public SortedFileCommandContainer sort() {
+			SortedFileCommandContainer out = new SortedFileCommandContainer();
+
+			/*
+			 *  Fill the HashMap in SortedFileCommandContainer with empty FileCommandsInCommentList
+			 *  for each different FileCommand name found in this UnsortedFileCommandContainer.
+			 */
+			for (FileCommandsInCommentList unsortedFileCommandsList : this) {
+				if (unsortedFileCommandsList != null) {
+					for (PlaybackFileCommand command : unsortedFileCommandsList) {
+						out.put(command.getName(), new FileCommandsInTickList());
 					}
 				}
 			}
 
-			for (List<PlaybackFileCommand> lists : list) {
-				for (Map.Entry<String, PlaybackFileCommandLine> entry : this.entrySet()) {
-					String key = entry.getKey();
-					List<PlaybackFileCommand> val = entry.getValue();
+			/**
+			 * Add the FileCommands to the previously created FileCommandsInCommentLists
+			 */
+			for (FileCommandsInCommentList unsortedFileCommandsList : this) {
+				/*
+				 * If the file command is not present in the comment, we have to add
+				 * null to the sortedFileCommandsList.
+				 * 
+				 * To do that, we iterate through all entries in the HashMap
+				 */
+				for (Map.Entry<String, FileCommandsInTickList> entry : out.entrySet()) {
+
+					String sortedKey = entry.getKey();
+					FileCommandsInTickList sortedFileCommandsList = entry.getValue();
 
 					boolean valuePresent = false;
-					if (lists != null) {
-						for (PlaybackFileCommand command : lists) {
-							if (key.equals(command.getName())) {
+					if (unsortedFileCommandsList != null) {
+						/**
+						 * Iterates through all filecommands in a comment
+						 * and adds it to the sorted list if found
+						 */
+						for (PlaybackFileCommand command : unsortedFileCommandsList) {
+							if (sortedKey.equals(command.getName())) {
 								valuePresent = true;
-								val.add(command);
+								sortedFileCommandsList.add(command);
 							}
 						}
 					}
+					/**
+					 * If the value is not found,
+					 * add null to indicate that the
+					 * file command is missing from this comment
+					 */
 					if (!valuePresent) {
-						val.add(null);
+						sortedFileCommandsList.add(null);
 					}
 				}
 			}
+			return out;
 		}
+	}
 
+	/**
+	 * <p>List of FileCommands in one tick.
+	 * <p>This class is the same as <code>ArrayList&lt;PlaybackFileCommand&gt;</code>
+	 * <p>In a tick, you can have multiple file commands for each subtick, hence a list is needed to store them all.
+	 * <p>Used in {@link PlaybackFileCommandExtension PlaybackFileCommandExtensions} as this format makes it easier to deal with processing FileCommands during playback or recording
+	 * <h5>Example</h5>
+	 * <pre>
+	 * // $desyncMonitor(13, 0, 1, 1, 1, 1);
+	 * // $desyncMonitor(13, 0, 1, 2, 1, 1);
+	 * // $desyncMonitor(13, 0, 1, 10, 1, 1);
+	 * </pre>
+	 * <p>This would translate into an ArrayList like
+	 * <pre>
+	 * [$desyncMonitor(13, 0, 1, 1, 1, 1);, $desyncMonitor(13, 0, 1, 2, 1, 1);, $desyncMonitor(13, 0, 1, 10, 1, 1);]
+	 * </pre>
+	 * 
+	 * <p>Used in {@link SortedFileCommandContainer} for processing file commands, either playing back or recording
+	 * <p>Although this class is the same as {@link FileCommandsInCommentList}, their use case differs slightly,<br>
+	 * hence I created 2 classes for the sake of clarity.
+	 * 
+	 * @author Scribble
+	 */
+	public static class FileCommandsInTickList extends ArrayList<PlaybackFileCommand> {
+	}
+
+	/**
+	 * <p>A LinkedHashMap for storing {@link FileCommandsInCommentList} sorted by the name of the FileCommand name.
+	 * <p>The key represents the FileCommand name, while the elements are the {@link FileCommandsInTickList}
+	 * <p>This stands in contrast to the {@link UnsortedFileCommandContainer}, which can be obtained by calling {@link SortedFileCommandContainer#unsort() unsort()}
+	 * <h5>Example</h5>
+	 * <pre>
+	 * // $desyncMonitor(13, 0, 1, 1, 1, 1); $hud(true);
+	 * // $desyncMonitor(16, 3, 1, 1, 1, 1); $hud(false);
+	 * // $label(Test); $hud(false);
+	 * </pre>
+	 * <p>This would translate into a LinkedHashMap like
+	 * <pre>
+	 * {
+	 * "desyncMonitor":
+	 * 	[$desyncMonitor(13, 0, 1, 1, 1, 1);, $desyncMonitor(16, 3, 1, 1, 1, 1);, null],
+	 * 
+	 * "hud":
+	 * 	[$hud(true);, $hud(false), $hud(false)],	&lt;- One {@link FileCommandsInTickList}
+	 * 
+	 * "label":
+	 * 	[null, null, $label(Test)]
+	 * }
+	 * <p>While null being the subticks that have no file commands of that type
+	 * 
+	 * <p>Additionally, these entries can be {@link SortedFileCommandContainer#split(Iterable) split} into multiple containers.
+	 * </pre>
+	 * @author Scribble
+	 */
+	public static class SortedFileCommandContainer extends LinkedHashMap<String, FileCommandsInTickList> {
+
+		/**
+		 * <p>Adds a new {@link PlaybackFileCommand} to the specified key.
+		 * <p>Creates a new {@link FileCommandsInTickList} if it's not already present
+		 * @param key The key for the list to add
+		 * @param fileCommand The {@link PlaybackFileCommand} to add to the list
+		 */
 		public void add(String key, PlaybackFileCommand fileCommand) {
-			PlaybackFileCommandLine toAdd = getOrDefault(key, new PlaybackFileCommandLine());
+			FileCommandsInTickList toAdd = getOrDefault(key, new FileCommandsInTickList());
 			if (toAdd.isEmpty()) {
 				put(key, toAdd);
 			}
@@ -181,39 +314,53 @@ public class PlaybackFileCommand {
 			toAdd.add(fileCommand);
 		}
 
-		public PlaybackFileCommandContainer split(String... keys) {
+		/**
+		 * <p>Creates a new {@link SortedFileCommandContainer} with only the keys present
+		 * @param keys The keys to split into
+		 * @return A new {@link SortedFileCommandContainer} with only the keys present
+		 */
+		public SortedFileCommandContainer split(String... keys) {
 			return split(Arrays.asList(keys));
 		}
 
-		public PlaybackFileCommandContainer split(Iterable<String> keys) {
-			PlaybackFileCommandContainer out = new PlaybackFileCommandContainer();
+		/**
+		 * <p>Creates a new {@link SortedFileCommandContainer} with only the keys present
+		 * @param keys The keys to split into
+		 * @return A new {@link SortedFileCommandContainer} with only the keys present
+		 */
+		public SortedFileCommandContainer split(Iterable<String> keys) {
+			SortedFileCommandContainer out = new SortedFileCommandContainer();
 			for (String key : keys) {
 				out.put(key, this.get(key));
 			}
 			return out;
 		}
 
-		public List<List<PlaybackFileCommand>> valuesBySubtick() {
-			List<List<PlaybackFileCommand>> out = new ArrayList<>();
+		/**
+		 * Sorts this HashMap by order of appeareance and merges filecommands into one line
+		 * @return An {@link UnsortedFileCommandContainer}
+		 */
+		public UnsortedFileCommandContainer unsort() {
+			UnsortedFileCommandContainer out = new UnsortedFileCommandContainer();
 
 			int biggestSize = 0;
-			for (PlaybackFileCommandLine list : values()) {
+			for (FileCommandsInTickList list : values()) {
 				if (list.size() > biggestSize) {
 					biggestSize = list.size();
 				}
 			}
 
 			for (int i = 0; i < biggestSize; i++) {
-				List<PlaybackFileCommand> commandListForOneLine = new ArrayList<>();
-				for (PlaybackFileCommandLine list : values()) {
+				FileCommandsInCommentList unsortedFileCommandsList = new FileCommandsInCommentList();
+				for (FileCommandsInTickList list : values()) {
 					if (i < list.size()) {
-						PlaybackFileCommand fc = list.get(i);
-						commandListForOneLine.add(fc);
+						PlaybackFileCommand fileCommand = list.get(i);
+						unsortedFileCommandsList.add(fileCommand);
 					} else {
-						commandListForOneLine.add(null);
+						unsortedFileCommandsList.add(null);
 					}
 				}
-				out.add(commandListForOneLine);
+				out.add(unsortedFileCommandsList);
 			}
 
 			return out;
@@ -221,11 +368,11 @@ public class PlaybackFileCommand {
 
 		@Override
 		public boolean equals(Object o) {
-			if (o instanceof PlaybackFileCommandContainer) {
-				PlaybackFileCommandContainer other = (PlaybackFileCommandContainer) o;
-				for (java.util.Map.Entry<String, PlaybackFileCommandLine> entry : other.entrySet()) {
+			if (o instanceof SortedFileCommandContainer) {
+				SortedFileCommandContainer other = (SortedFileCommandContainer) o;
+				for (java.util.Map.Entry<String, FileCommandsInTickList> entry : other.entrySet()) {
 					String key = entry.getKey();
-					PlaybackFileCommandLine val = entry.getValue();
+					FileCommandsInTickList val = entry.getValue();
 
 					if (!this.containsKey(key) && !this.get(key).equals(val))
 						return false;
@@ -234,9 +381,5 @@ public class PlaybackFileCommand {
 			}
 			return super.equals(o);
 		}
-	}
-
-	public static class PlaybackFileCommandLine extends ArrayList<PlaybackFileCommand> {
-
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommand.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommand.java
@@ -54,10 +54,32 @@ public class PlaybackFileCommand {
 		return String.format("$%s(%s);", name, String.join(", ", args));
 	}
 
+	/**
+	 * <p>Abstract class for a FileCommandExtension.
+	 * <p>Allows for creating custom FileCommands that can be stored within the TASfile<br>
+	 * to trigger custom behaviour when a playback is reaching that point
+	
+	 * @author Scribble
+	 */
 	public static abstract class PlaybackFileCommandExtension implements Registerable {
-
+		/**
+		 * The temporary directory of the {@link #fileCommandStorage}
+		 */
 		protected final Path tempDir;
 
+		/**
+		 * The list where all filecommands for this extension are stored
+		 */
+		protected BigArrayList<SortedFileCommandContainer> inlineFileCommandStorage;
+
+		/**
+		 * The list where all filecommands for this extension are stored
+		 */
+		protected BigArrayList<SortedFileCommandContainer> endlineFileCommandStorage;
+
+		/**
+		 * Creates a new extension with the default {@link #tempDir}
+		 */
 		public PlaybackFileCommandExtension() {
 			this((Path) null);
 		}
@@ -75,6 +97,8 @@ public class PlaybackFileCommand {
 		public PlaybackFileCommandExtension(Path tempDirectory) {
 			if (tempDirectory == null) {
 				tempDir = null;
+				inlineFileCommandStorage = new BigArrayList<>();
+				endlineFileCommandStorage = new BigArrayList<>();
 				return;
 			}
 
@@ -84,6 +108,8 @@ public class PlaybackFileCommand {
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
+			inlineFileCommandStorage = new BigArrayList<>(tempDir.toString());
+			endlineFileCommandStorage = new BigArrayList<>(tempDir.toString());
 		}
 
 		protected boolean enabled = false;
@@ -97,6 +123,14 @@ public class PlaybackFileCommand {
 		};
 
 		public void onClear() {
+			try {
+				inlineFileCommandStorage.clearMemory();
+				endlineFileCommandStorage.clearMemory();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			inlineFileCommandStorage = new BigArrayList<>();
+			endlineFileCommandStorage = new BigArrayList<>();
 		};
 
 		public void onRecord(long tick, InputContainer inputContainer) {
@@ -106,17 +140,49 @@ public class PlaybackFileCommand {
 		};
 
 		public SortedFileCommandContainer onSerialiseInlineComment(long tick, InputContainer inputContainer) {
-			return null;
+			SortedFileCommandContainer out = new SortedFileCommandContainer();
+			if (tick >= inlineFileCommandStorage.size())
+				return out;
+
+			SortedFileCommandContainer currentTick = inlineFileCommandStorage.get(tick);
+			if (currentTick == null)
+				return out;
+
+			for (String name : getFileCommandNames()) {
+				if (currentTick.get(name) != null)
+					out.putAll(currentTick.split(name));
+			}
+			return out;
 		}
 
-		public SortedFileCommandContainer onSerialiseEndlineComment(long currentTick, InputContainer inputContainer) {
-			return null;
+		public SortedFileCommandContainer onSerialiseEndlineComment(long tick, InputContainer inputContainer) {
+			SortedFileCommandContainer out = new SortedFileCommandContainer();
+			if (tick >= endlineFileCommandStorage.size())
+				return out;
+
+			SortedFileCommandContainer currentTick = endlineFileCommandStorage.get(tick);
+			if (currentTick == null)
+				return out;
+
+			for (String name : getFileCommandNames()) {
+				if (currentTick.get(name) != null)
+					out.putAll(currentTick.split(name));
+			}
+			return out;
 		}
 
 		public void onDeserialiseInlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
+			if (fileCommandContainer == null)
+				return;
+
+			inlineFileCommandStorage.add(fileCommandContainer);
 		}
 
 		public void onDeserialiseEndlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
+			if (fileCommandContainer == null)
+				return;
+
+			endlineFileCommandStorage.add(fileCommandContainer);
 		}
 
 		public boolean isEnabled() {
@@ -331,7 +397,8 @@ public class PlaybackFileCommand {
 		public SortedFileCommandContainer split(Iterable<String> keys) {
 			SortedFileCommandContainer out = new SortedFileCommandContainer();
 			for (String key : keys) {
-				out.put(key, this.get(key));
+				if (this.containsKey(key))
+					out.put(key, this.get(key));
 			}
 			return out;
 		}

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommand.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommand.java
@@ -437,6 +437,8 @@ public class PlaybackFileCommand {
 		public boolean equals(Object o) {
 			if (o instanceof SortedFileCommandContainer) {
 				SortedFileCommandContainer other = (SortedFileCommandContainer) o;
+				if (this.size() != other.size())
+					return false;
 				for (java.util.Map.Entry<String, FileCommandsInTickList> entry : other.entrySet()) {
 					String key = entry.getKey();
 					FileCommandsInTickList val = entry.getValue();

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommandsRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommandsRegistry.java
@@ -9,8 +9,9 @@ import com.minecrafttas.mctcommon.Configuration;
 import com.minecrafttas.mctcommon.registry.AbstractRegistry;
 import com.minecrafttas.tasmod.events.EventPlaybackClient;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.UnsortedFileCommandContainer;
 import com.minecrafttas.tasmod.registries.TASmodConfig;
 
 public class PlaybackFileCommandsRegistry extends AbstractRegistry<PlaybackFileCommandExtension> implements EventPlaybackClient.EventRecordTick, EventPlaybackClient.EventPlaybackTick, EventPlaybackClient.EventRecordClear {
@@ -110,41 +111,41 @@ public class PlaybackFileCommandsRegistry extends AbstractRegistry<PlaybackFileC
 		});
 	}
 
-	public PlaybackFileCommandContainer handleOnSerialiseInline(long currentTick, InputContainer container) {
-		PlaybackFileCommandContainer out = new PlaybackFileCommandContainer();
+	public UnsortedFileCommandContainer handleOnSerialiseInline(long currentTick, InputContainer container) {
+		SortedFileCommandContainer out = new SortedFileCommandContainer();
 		for (PlaybackFileCommandExtension extension : enabledExtensions) {
-			PlaybackFileCommandContainer extensionContainer = extension.onSerialiseInlineComment(currentTick, container);
+			SortedFileCommandContainer extensionContainer = extension.onSerialiseInlineComment(currentTick, container);
 			if (extensionContainer != null) {
 				out.putAll(extensionContainer);
 			}
 		}
-		return out;
+		return out.unsort();
 	}
 
-	public PlaybackFileCommandContainer handleOnSerialiseEndline(long currentTick, InputContainer container) {
-		PlaybackFileCommandContainer out = new PlaybackFileCommandContainer();
+	public UnsortedFileCommandContainer handleOnSerialiseEndline(long currentTick, InputContainer container) {
+		SortedFileCommandContainer out = new SortedFileCommandContainer();
 		for (PlaybackFileCommandExtension extension : enabledExtensions) {
-			PlaybackFileCommandContainer extensionContainer = extension.onSerialiseEndlineComment(currentTick, container);
+			SortedFileCommandContainer extensionContainer = extension.onSerialiseEndlineComment(currentTick, container);
 			if (extensionContainer != null) {
 				out.putAll(extensionContainer);
 			}
 		}
-		return out;
+		return out.unsort();
 	}
 
-	public void handleOnDeserialiseInline(long currentTick, InputContainer deserialisedContainer, List<List<PlaybackFileCommand>> inlineFileCommands) {
-		PlaybackFileCommandContainer fileCommandContainer = new PlaybackFileCommandContainer(inlineFileCommands);
+	public void handleOnDeserialiseInline(long currentTick, InputContainer deserialisedContainer, UnsortedFileCommandContainer unsortedInlineFileCommands) {
+		SortedFileCommandContainer fileCommandContainer = unsortedInlineFileCommands.sort();
 		for (PlaybackFileCommandExtension extension : enabledExtensions) {
 			String[] fileCommandNames = extension.getFileCommandNames();
 			extension.onDeserialiseInlineComment(currentTick, deserialisedContainer, fileCommandContainer.split(fileCommandNames));
 		}
 	}
 
-	public void handleOnDeserialiseEndline(long currentTick, InputContainer deserialisedContainer, List<List<PlaybackFileCommand>> endlineFileCommands) {
-		PlaybackFileCommandContainer fileCommandContainer = new PlaybackFileCommandContainer(endlineFileCommands);
+	public void handleOnDeserialiseEndline(long currentTick, InputContainer deserialisedContainer, UnsortedFileCommandContainer unsortedEndlineFileCommands) {
+		SortedFileCommandContainer sortedEndlineFileCommands = unsortedEndlineFileCommands.sort();
 		for (PlaybackFileCommandExtension extension : enabledExtensions) {
 			String[] fileCommandNames = extension.getFileCommandNames();
-			extension.onDeserialiseEndlineComment(currentTick, deserialisedContainer, fileCommandContainer.split(fileCommandNames));
+			extension.onDeserialiseEndlineComment(currentTick, deserialisedContainer, sortedEndlineFileCommands.split(fileCommandNames));
 		}
 	}
 
@@ -179,9 +180,5 @@ public class PlaybackFileCommandsRegistry extends AbstractRegistry<PlaybackFileC
 		});
 		config.set(TASmodConfig.EnabledFileCommands, String.join(", ", nameList));
 		config.saveToXML();
-	}
-
-	public static class FileCommandsInComment extends ArrayList<PlaybackFileCommand> {
-
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommandsRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommandsRegistry.java
@@ -180,4 +180,8 @@ public class PlaybackFileCommandsRegistry extends AbstractRegistry<PlaybackFileC
 		config.set(TASmodConfig.EnabledFileCommands, String.join(", ", nameList));
 		config.saveToXML();
 	}
+
+	public static class FileCommandsInComment extends ArrayList<PlaybackFileCommand> {
+
+	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommandsRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommandsRegistry.java
@@ -150,9 +150,13 @@ public class PlaybackFileCommandsRegistry extends AbstractRegistry<PlaybackFileC
 	}
 
 	@Override
+	public void onRecordingClear() {
+		onClear();
+	}
+
 	public void onClear() {
-		REGISTRY.values().forEach(fc -> {
-			fc.onClear();
+		REGISTRY.values().forEach(fileCommandExtension -> {
+			fileCommandExtension.onClear();
 		});
 	}
 

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/DesyncMonitorFileCommandExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/DesyncMonitorFileCommandExtension.java
@@ -14,7 +14,7 @@ import com.minecrafttas.tasmod.events.EventPlaybackClient;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandContainer;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
 import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackLoadException;
 
@@ -97,8 +97,8 @@ public class DesyncMonitorFileCommandExtension extends PlaybackFileCommandExtens
 	}
 
 	@Override
-	public PlaybackFileCommandContainer onSerialiseEndlineComment(long currentTick, InputContainer inputContainer) {
-		PlaybackFileCommandContainer out = new PlaybackFileCommandContainer();
+	public SortedFileCommandContainer onSerialiseEndlineComment(long currentTick, InputContainer inputContainer) {
+		SortedFileCommandContainer out = new SortedFileCommandContainer();
 		MonitorContainer monitoredValues = monitorContainer.get(currentTick);
 		PlaybackFileCommand command = new PlaybackFileCommand("desyncMonitor", monitoredValues.toStringArray());
 
@@ -108,7 +108,7 @@ public class DesyncMonitorFileCommandExtension extends PlaybackFileCommandExtens
 	}
 
 	@Override
-	public void onDeserialiseEndlineComment(long tick, InputContainer container, PlaybackFileCommandContainer fileCommandContainer) {
+	public void onDeserialiseEndlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
 		List<PlaybackFileCommand> commandsEndline = fileCommandContainer.get("desyncMonitor");
 		if (commandsEndline == null || commandsEndline.isEmpty()) {
 			recordNull(tick);

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/DesyncMonitorFileCommandExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/DesyncMonitorFileCommandExtension.java
@@ -11,11 +11,11 @@ import java.util.Locale;
 import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.TASmodClient;
 import com.minecrafttas.tasmod.events.EventPlaybackClient;
-import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
 import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackLoadException;
 
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/LabelFileCommandExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/LabelFileCommandExtension.java
@@ -1,9 +1,7 @@
 package com.minecrafttas.tasmod.playback.filecommands.builtin;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
-import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.FileCommandsInTickList;
@@ -14,21 +12,17 @@ public class LabelFileCommandExtension extends PlaybackFileCommandExtension {
 
 	private String labelText = "";
 
-	BigArrayList<SortedFileCommandContainer> label = new BigArrayList<>();
-
 	public LabelFileCommandExtension() {
 		this("label");
 	}
 
 	public LabelFileCommandExtension(String tempDirName) {
 		super(tempDirName);
-		this.label = new BigArrayList<>(tempDir.toString());
 		enabled = true;
 	}
 
 	public LabelFileCommandExtension(Path tempDir) {
 		super(tempDir);
-		this.label = new BigArrayList<>(tempDir.toString());
 		enabled = true;
 	}
 
@@ -43,27 +37,11 @@ public class LabelFileCommandExtension extends PlaybackFileCommandExtension {
 	}
 
 	@Override
-	public SortedFileCommandContainer onSerialiseInlineComment(long tick, InputContainer inputContainer) {
-		SortedFileCommandContainer fileCommandContainer = new SortedFileCommandContainer();
-		if (label.size() != 0 && label.get(tick).get("label") != null) {
-			fileCommandContainer = label.get(tick);
-		}
-		return fileCommandContainer;
-	}
-
-	@Override
-	public void onDeserialiseInlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
-		if (fileCommandContainer.containsKey("label")) {
-			label.add(fileCommandContainer.split("label"));
-		}
-	}
-
-	@Override
 	public void onPlayback(long tick, InputContainer inputContainer) {
-		if (label.size() <= tick) {
+		if (inlineFileCommandStorage.size() <= tick) {
 			return;
 		}
-		SortedFileCommandContainer containerInTick = label.get(tick);
+		SortedFileCommandContainer containerInTick = inlineFileCommandStorage.get(tick);
 		if (containerInTick == null) {
 			return;
 		}
@@ -74,19 +52,15 @@ public class LabelFileCommandExtension extends PlaybackFileCommandExtension {
 		}
 
 		for (PlaybackFileCommand command : line) {
+			if (command == null)
+				continue;
 			labelText = String.join(", ", command.getArgs());
 		}
 	}
 
 	@Override
 	public void onClear() {
-		try {
-			label.clearMemory();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-
-		label = new BigArrayList<>();
+		super.onClear();
 		labelText = "";
 	}
 

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/LabelFileCommandExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/LabelFileCommandExtension.java
@@ -6,15 +6,15 @@ import java.nio.file.Path;
 import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandContainer;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.FileCommandsInTickList;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandLine;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
 
 public class LabelFileCommandExtension extends PlaybackFileCommandExtension {
 
 	private String labelText = "";
 
-	BigArrayList<PlaybackFileCommandContainer> label = new BigArrayList<>();
+	BigArrayList<SortedFileCommandContainer> label = new BigArrayList<>();
 
 	public LabelFileCommandExtension() {
 		this("label");
@@ -43,8 +43,8 @@ public class LabelFileCommandExtension extends PlaybackFileCommandExtension {
 	}
 
 	@Override
-	public PlaybackFileCommandContainer onSerialiseInlineComment(long tick, InputContainer inputContainer) {
-		PlaybackFileCommandContainer fileCommandContainer = new PlaybackFileCommandContainer();
+	public SortedFileCommandContainer onSerialiseInlineComment(long tick, InputContainer inputContainer) {
+		SortedFileCommandContainer fileCommandContainer = new SortedFileCommandContainer();
 		if (label.size() != 0 && label.get(tick).get("label") != null) {
 			fileCommandContainer = label.get(tick);
 		}
@@ -52,7 +52,7 @@ public class LabelFileCommandExtension extends PlaybackFileCommandExtension {
 	}
 
 	@Override
-	public void onDeserialiseInlineComment(long tick, InputContainer container, PlaybackFileCommandContainer fileCommandContainer) {
+	public void onDeserialiseInlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
 		if (fileCommandContainer.containsKey("label")) {
 			label.add(fileCommandContainer.split("label"));
 		}
@@ -63,12 +63,12 @@ public class LabelFileCommandExtension extends PlaybackFileCommandExtension {
 		if (label.size() <= tick) {
 			return;
 		}
-		PlaybackFileCommandContainer containerInTick = label.get(tick);
+		SortedFileCommandContainer containerInTick = label.get(tick);
 		if (containerInTick == null) {
 			return;
 		}
 
-		PlaybackFileCommandLine line = containerInTick.get("label");
+		FileCommandsInTickList line = containerInTick.get("label");
 		if (line == null) {
 			return;
 		}

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/OptionsFileCommandExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/OptionsFileCommandExtension.java
@@ -1,9 +1,7 @@
 package com.minecrafttas.tasmod.playback.filecommands.builtin;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
-import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
@@ -16,21 +14,17 @@ public class OptionsFileCommandExtension extends PlaybackFileCommandExtension {
 
 	private boolean shouldRenderHud = true;
 
-	BigArrayList<SortedFileCommandContainer> hud;
-
 	public OptionsFileCommandExtension() {
 		this("hud");
 	}
 
 	public OptionsFileCommandExtension(String tempDirName) {
 		super(tempDirName);
-		hud = new BigArrayList<>(tempDir.toString());
 		enabled = true;
 	}
 
 	public OptionsFileCommandExtension(Path tempDir) {
 		super(tempDir);
-		this.hud = new BigArrayList<>(tempDir.toString());
 		enabled = true;
 	}
 
@@ -45,27 +39,11 @@ public class OptionsFileCommandExtension extends PlaybackFileCommandExtension {
 	}
 
 	@Override
-	public SortedFileCommandContainer onSerialiseInlineComment(long tick, InputContainer inputContainer) {
-		SortedFileCommandContainer fileCommandContainer = new SortedFileCommandContainer();
-		if (hud.size() != 0 && hud.get(tick).get("hud") != null) {
-			fileCommandContainer = hud.get(tick);
-		}
-		return fileCommandContainer;
-	}
-
-	@Override
-	public void onDeserialiseInlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
-		if (fileCommandContainer.containsKey("hud")) {
-			hud.add(fileCommandContainer.split("hud"));
-		}
-	}
-
-	@Override
 	public void onPlayback(long tick, InputContainer inputContainer) {
-		if (hud.size() <= tick) {
+		if (inlineFileCommandStorage.size() <= tick) {
 			return;
 		}
-		SortedFileCommandContainer containerInTick = hud.get(tick);
+		SortedFileCommandContainer containerInTick = inlineFileCommandStorage.get(tick);
 		if (containerInTick == null) {
 			return;
 		}
@@ -76,6 +54,8 @@ public class OptionsFileCommandExtension extends PlaybackFileCommandExtension {
 		}
 
 		for (PlaybackFileCommand command : line) {
+			if (command == null)
+				continue;
 			String[] args = command.getArgs();
 			if (args.length == 1) {
 				/*
@@ -103,20 +83,8 @@ public class OptionsFileCommandExtension extends PlaybackFileCommandExtension {
 	}
 
 	@Override
-	public void onRecord(long tick, InputContainer inputContainer) {
-		// TODO Auto-generated method stub
-		super.onRecord(tick, inputContainer);
-	}
-
-	@Override
 	public void onClear() {
-		try {
-			hud.clearMemory();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-
-		hud = new BigArrayList<>();
+		super.onClear();
 		shouldRenderHud = true;
 	}
 

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/OptionsFileCommandExtension.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/builtin/OptionsFileCommandExtension.java
@@ -7,16 +7,16 @@ import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandContainer;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.FileCommandsInTickList;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandLine;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
 
 public class OptionsFileCommandExtension extends PlaybackFileCommandExtension {
 
 	private boolean shouldRenderHud = true;
 
-	BigArrayList<PlaybackFileCommandContainer> hud;
+	BigArrayList<SortedFileCommandContainer> hud;
 
 	public OptionsFileCommandExtension() {
 		this("hud");
@@ -45,8 +45,8 @@ public class OptionsFileCommandExtension extends PlaybackFileCommandExtension {
 	}
 
 	@Override
-	public PlaybackFileCommandContainer onSerialiseInlineComment(long tick, InputContainer inputContainer) {
-		PlaybackFileCommandContainer fileCommandContainer = new PlaybackFileCommandContainer();
+	public SortedFileCommandContainer onSerialiseInlineComment(long tick, InputContainer inputContainer) {
+		SortedFileCommandContainer fileCommandContainer = new SortedFileCommandContainer();
 		if (hud.size() != 0 && hud.get(tick).get("hud") != null) {
 			fileCommandContainer = hud.get(tick);
 		}
@@ -54,7 +54,7 @@ public class OptionsFileCommandExtension extends PlaybackFileCommandExtension {
 	}
 
 	@Override
-	public void onDeserialiseInlineComment(long tick, InputContainer container, PlaybackFileCommandContainer fileCommandContainer) {
+	public void onDeserialiseInlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
 		if (fileCommandContainer.containsKey("hud")) {
 			hud.add(fileCommandContainer.split("hud"));
 		}
@@ -65,12 +65,12 @@ public class OptionsFileCommandExtension extends PlaybackFileCommandExtension {
 		if (hud.size() <= tick) {
 			return;
 		}
-		PlaybackFileCommandContainer containerInTick = hud.get(tick);
+		SortedFileCommandContainer containerInTick = hud.get(tick);
 		if (containerInTick == null) {
 			return;
 		}
 
-		PlaybackFileCommandLine line = containerInTick.get("hud");
+		FileCommandsInTickList line = containerInTick.get("hud");
 		if (line == null) {
 			return;
 		}

--- a/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/metadata/PlaybackMetadataRegistry.java
@@ -52,7 +52,7 @@ public class PlaybackMetadataRegistry extends AbstractRegistry<PlaybackMetadataE
 	}
 	
 	@Override
-	public void onClear() {
+	public void onRecordingClear() {
 		REGISTRY.forEach((key, extension) ->{
 			extension.onClear();
 		});

--- a/src/main/java/com/minecrafttas/tasmod/playback/tasfile/flavor/SerialiserFlavorBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/tasfile/flavor/SerialiserFlavorBase.java
@@ -21,8 +21,9 @@ import com.minecrafttas.mctcommon.registry.Registerable;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.CommentContainer;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandContainer;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.FileCommandsInCommentList;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.UnsortedFileCommandContainer;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
 import com.minecrafttas.tasmod.playback.tasfile.PlaybackSerialiser;
 import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackLoadException;
@@ -42,7 +43,7 @@ import com.minecrafttas.tasmod.virtual.VirtualMouse;
  * <p>Adding functionality to playback should be made via {@link PlaybackFileCommand PlaybackFileCommands}<br>
  * instead of creating a new syntax and adding new information to the header should be made via {@link PlaybackMetadata}
  * 
- * <h2>Sections</h2>
+ * <h4>Sections</h4>
  * <p>The TASfile has 2 main sections, which are called seperately by the {@link PlaybackSerialiser}:
  * 
  * <ol>
@@ -158,7 +159,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * serialiseHeader
 	 *	├── {@link #headerStart()}
 	 *	├── {@link #serialiseFlavorName(List)}
-	 *	├── {@link #serialiseFileCommandNames(List)}
+	 *	├── {@link #serialiseEnabledFileCommandNames(List)}
 	 *	├── {@link #serialiseMetadata(List)}
 	 *	│   ├── {@link #serialiseMetadataName(List, String)}
 	 *	│   └── {@link #serialiseMetadataValues(List, LinkedHashMap)}
@@ -168,7 +169,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * <pre>
 	 * ##################### TASfile ####################					// {@link #headerStart()}
 	 * Flavor: beta1 										// {@link #serialiseFlavorName(List)}
-	 * FileCommand-Extensions: tasmod_desyncMonitor@v1, tasmod_options@v1, tasmod_label@v1	// {@link #serialiseFileCommandNames(List)}
+	 * FileCommand-Extensions: tasmod_desyncMonitor@v1, tasmod_options@v1, tasmod_label@v1	// {@link #serialiseEnabledFileCommandNames(List)}
 	 * 
 	 * --------------------- Credits -------------------- 					// {@link #serialiseMetadataName(List, String)}
 	 * Title:Insert TAS category here 							// {@link #serialiseMetadataValues(List, LinkedHashMap)}
@@ -191,7 +192,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		List<String> out = new ArrayList<>();
 		out.add(headerStart());
 		serialiseFlavorName(out);
-		serialiseFileCommandNames(out);
+		serialiseEnabledFileCommandNames(out);
 		serialiseMetadata(out);
 		out.add(headerEnd());
 		return out;
@@ -220,7 +221,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * </pre>
 	 * @param out The serialised lines, passed by reference
 	 */
-	protected void serialiseFileCommandNames(List<String> out) {
+	protected void serialiseEnabledFileCommandNames(List<String> out) {
 		List<String> stringlist = new ArrayList<>();
 		List<PlaybackFileCommandExtension> extensionList = TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.getEnabled();
 		if (processExtensions) {
@@ -313,7 +314,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 *     │   └── {@link #serialiseMouseSubtick(VirtualMouse)}
 	 *     ├── {@link #serialiseCameraAngle(VirtualCameraAngle)}
 	 *     │   └── {@link #serialiseCameraAngleSubtick(VirtualCameraAngle)}
-	 *     ├── {@link #serialiseInlineComments(List, List)}
+	 *     ├── {@link #serialiseInlineComments(List, UnsortedFileCommandContainer)}
 	 *     │   ├── {@link #serialiseInlineComment(String)}
 	 *     │   └── {@link #serialiseFileCommandsInline(List)}
 	 *     │       └── {@link #serialiseFileCommand(PlaybackFileCommand)}
@@ -357,12 +358,12 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		List<String> serialisedCameraAngle = serialiseCameraAngle(container.getCameraAngle());
 		pruneListEndEmpty(serialisedCameraAngle);
 
-		PlaybackFileCommandContainer fileCommandsInline = TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnSerialiseInline(currentTick, container);
-		PlaybackFileCommandContainer fileCommandsEndline = TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnSerialiseEndline(currentTick, container);
+		UnsortedFileCommandContainer fileCommandsInline = TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnSerialiseInline(currentTick, container);
+		UnsortedFileCommandContainer fileCommandsEndline = TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnSerialiseEndline(currentTick, container);
 
 		CommentContainer comments = container.getComments();
-		List<String> serialisedInlineComments = serialiseInlineComments(comments.getInlineComments(), fileCommandsInline.valuesBySubtick());
-		List<String> serialisedEndlineComments = serialiseEndlineComments(comments.getEndlineComments(), fileCommandsEndline.valuesBySubtick());
+		List<String> serialisedInlineComments = serialiseInlineComments(comments.getInlineComments(), fileCommandsInline);
+		List<String> serialisedEndlineComments = serialiseEndlineComments(comments.getEndlineComments(), fileCommandsEndline);
 
 		mergeInputs(out, serialisedKeyboard, serialisedMouse, serialisedCameraAngle, serialisedInlineComments, serialisedEndlineComments);
 	}
@@ -508,10 +509,10 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * @param fileCommandsInline The list of file commands to serialise
 	 * @return List of comments including file commands
 	 */
-	protected List<String> serialiseInlineComments(List<String> inlineComments, List<List<PlaybackFileCommand>> fileCommandsInline) {
+	protected List<String> serialiseInlineComments(List<String> inlineComments, UnsortedFileCommandContainer fileCommandsInline) {
 		List<String> out = new ArrayList<>();
 
-		Queue<List<PlaybackFileCommand>> fileCommandQueue = null;
+		Queue<FileCommandsInCommentList> fileCommandQueue = null;
 		if (fileCommandsInline != null) {
 			fileCommandQueue = new LinkedList<>(fileCommandsInline);
 		}
@@ -581,10 +582,10 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * @param fileCommandsEndline The list of file commands to serialise
 	 * @return The serialised comments
 	 */
-	protected List<String> serialiseEndlineComments(List<String> endlineComments, List<List<PlaybackFileCommand>> fileCommandsEndline) {
+	protected List<String> serialiseEndlineComments(List<String> endlineComments, UnsortedFileCommandContainer fileCommandsEndline) {
 		List<String> out = new ArrayList<>();
 
-		Queue<List<PlaybackFileCommand>> fileCommandQueue = null;
+		Queue<FileCommandsInCommentList> fileCommandQueue = null;
 		if (fileCommandsEndline != null) {
 			fileCommandQueue = new LinkedList<>(fileCommandsEndline);
 		}
@@ -656,7 +657,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * @param fileCommands The file commands to serialise
 	 * @return A string of serialised file commands or null if fileCommands is null
 	 */
-	protected String serialiseFileCommandsInline(List<PlaybackFileCommand> fileCommands) {
+	protected String serialiseFileCommandsInline(FileCommandsInCommentList fileCommands) {
 		// File commands is null if there are no file commands in the comment.
 		// Return null if that is the case
 		if (fileCommands == null) {
@@ -680,7 +681,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * @param fileCommands The file commands to serialise
 	 * @return A string of serialised file commands or null if fileCommands is null
 	 */
-	protected String serialiseFileCommandsEndline(List<PlaybackFileCommand> fileCommands) {
+	protected String serialiseFileCommandsEndline(FileCommandsInCommentList fileCommands) {
 		return serialiseFileCommandsInline(fileCommands);
 	}
 
@@ -924,14 +925,14 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * <pre>
 	 *  deserialiseHeader
 	 *  ├── {@link #deserialiseMetadata(List)}
-	 *  └── {@link #deserialiseFileCommandNames(List)}
+	 *  └── {@link #deserialiseEnabledFileCommandNames(List)}
 	 * </pre>
 	 * @param headerLines The header lines to deserialise
 	 * @see #serialiseHeader()
 	 */
 	public void deserialiseHeader(List<String> headerLines) {
 		deserialiseMetadata(headerLines);
-		deserialiseFileCommandNames(headerLines);
+		deserialiseEnabledFileCommandNames(headerLines);
 	}
 
 	/**
@@ -978,10 +979,10 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	/**
 	 * <p>Deserialises file command extension names and enables them
 	 * @param headerLines The header lines to search
-	 * @see #serialiseFileCommandNames(List)
+	 * @see #serialiseEnabledFileCommandNames(List)
 	 * @throws PlaybackLoadException If the "FileCommand-Extensions" keyword is not found in the header
 	 */
-	protected void deserialiseFileCommandNames(List<String> headerLines) {
+	protected void deserialiseEnabledFileCommandNames(List<String> headerLines) {
 		if (!processExtensions) // Stops FileCommandProcessing
 			return;
 
@@ -1106,7 +1107,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * ---------------------
 	 * </pre>
 	 * 
-	 * <h2>Logic</h2>
+	 * <h4>Logic</h4>
 	 * <ol>
 	 * <li>Phase: None
 	 * <ol>
@@ -1207,14 +1208,14 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		List<String> tickLines = new ArrayList<>();
 		splitContainer(containerLines, inlineComments, tickLines);
 
-		List<List<PlaybackFileCommand>> inlineFileCommands = new ArrayList<>();
+		UnsortedFileCommandContainer inlineFileCommands = new UnsortedFileCommandContainer();
 		deserialiseMultipleInlineComments(inlineComments, inlineFileCommands);
 
 		List<String> keyboardStrings = new ArrayList<>();
 		List<String> mouseStrings = new ArrayList<>();
 		List<String> cameraAngleStrings = new ArrayList<>();
 		List<String> endlineComments = new ArrayList<>();
-		List<List<PlaybackFileCommand>> endlineFileCommands = new ArrayList<>();
+		UnsortedFileCommandContainer endlineFileCommands = new UnsortedFileCommandContainer();
 
 		splitInputs(tickLines, keyboardStrings, mouseStrings, cameraAngleStrings, endlineComments, endlineFileCommands);
 
@@ -1252,9 +1253,9 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		}
 	}
 
-	protected void deserialiseMultipleInlineComments(List<String> inlineComments, List<List<PlaybackFileCommand>> inlineFileCommands) {
+	protected void deserialiseMultipleInlineComments(List<String> inlineComments, UnsortedFileCommandContainer inlineFileCommands) {
 		for (int i = 0; i < inlineComments.size(); i++) {
-			List<PlaybackFileCommand> deserialisedFileCommand = new ArrayList<>();
+			FileCommandsInCommentList deserialisedFileCommand = new FileCommandsInCommentList();
 			String comment = inlineComments.get(i);
 
 			inlineComments.set(i, deserialiseInlineComment(comment, deserialisedFileCommand));
@@ -1266,7 +1267,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		}
 	}
 
-	protected String deserialiseInlineComment(String comment, List<PlaybackFileCommand> deserialisedFileCommands) {
+	protected String deserialiseInlineComment(String comment, FileCommandsInCommentList deserialisedFileCommands) {
 		comment = deserialiseFileCommandsInline(comment, deserialisedFileCommands);
 		comment = extract("^// ?(.+)", comment, 1);
 		if (comment != null) {
@@ -1278,7 +1279,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		return comment;
 	}
 
-	protected String deserialiseEndlineComment(String comment, List<PlaybackFileCommand> deserialisedFileCommands) {
+	protected String deserialiseEndlineComment(String comment, FileCommandsInCommentList deserialisedFileCommands) {
 		comment = deserialiseFileCommandsEndline(comment, deserialisedFileCommands);
 		comment = extract("^// ?(.+)", comment, 1);
 		if (comment != null) {
@@ -1290,7 +1291,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		return comment;
 	}
 
-	protected String deserialiseFileCommandsInline(String comment, List<PlaybackFileCommand> deserialisedFileCommands) {
+	protected String deserialiseFileCommandsInline(String comment, FileCommandsInCommentList deserialisedFileCommands) {
 		Matcher matcher = extract("\\$(.+?)\\((.*?)\\);", comment);
 
 		// Iterate through all file commands and add each to the list
@@ -1308,7 +1309,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		return comment;
 	}
 
-	protected String deserialiseFileCommandsEndline(String comment, List<PlaybackFileCommand> deserialisedFileCommands) {
+	protected String deserialiseFileCommandsEndline(String comment, FileCommandsInCommentList deserialisedFileCommands) {
 		Matcher matcher = extract("\\$(.+?)\\((.*?)\\);", comment);
 
 		// Iterate through all file commands and add each to the list
@@ -1541,7 +1542,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		return out;
 	}
 
-	protected void splitInputs(List<String> lines, List<String> serialisedKeyboard, List<String> serialisedMouse, List<String> serialisedCameraAngle, List<String> commentsAtEnd, List<List<PlaybackFileCommand>> endlineFileCommands) {
+	protected void splitInputs(List<String> lines, List<String> serialisedKeyboard, List<String> serialisedMouse, List<String> serialisedCameraAngle, List<String> commentsAtEnd, UnsortedFileCommandContainer endlineFileCommands) {
 
 		String previousCamera = null;
 		if (previousInputContainer != null) {
@@ -1568,7 +1569,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 						serialisedCameraAngle.add(previousCamera);
 				}
 
-				List<PlaybackFileCommand> deserialisedFileCommands = new ArrayList<>();
+				FileCommandsInCommentList deserialisedFileCommands = new FileCommandsInCommentList();
 
 				String endlineComment = line.substring(tickMatcher.group(0).length());
 				commentsAtEnd.add(deserialiseEndlineComment(endlineComment, deserialisedFileCommands));

--- a/src/main/java/com/minecrafttas/tasmod/playback/tasfile/flavor/SerialiserFlavorBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/tasfile/flavor/SerialiserFlavorBase.java
@@ -318,9 +318,9 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 *     │   ├── {@link #serialiseInlineComment(String)}
 	 *     │   └── {@link #serialiseFileCommandsInline(List)}
 	 *     │       └── {@link #serialiseFileCommand(PlaybackFileCommand)}
-	 *     ├── {@link #serialiseEndlineComments(List, List)}	// Same as serialiseInlineComments
+	 *     ├── {@link #serialiseEndlineComments(List, UnsortedFileCommandContainer)}	// Same as serialiseInlineComments
 	 *     │   ├── {@link #serialiseEndlineComment(String)}
-	 *     │   └── {@link #serialiseFileCommandsEndline(List)}	// Unused
+	 *     │   └── {@link #serialiseFileCommandsEndline(FileCommandsInCommentList)}	// Unused
 	 *     │       └── {@link #serialiseFileCommand(PlaybackFileCommand)}
 	 *     └── {@link #mergeInputs(BigArrayList, List, List, List, List)}
 	 *         ├── {@link #mergeInput(long, String, String, String, String)}
@@ -1011,12 +1011,12 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * deserialise
 	 * ├── {@link #extractContainer(List, BigArrayList, long)}
 	 * └── {@link #deserialiseContainer(BigArrayList, List)}
-	 *     ├── {@link #deserialiseMultipleInlineComments(List, List)}
-	 *     │   └── {@link #deserialiseInlineComment(String, List)}
-	 *     │       └── {@link #deserialiseFileCommandsInline(String, List)}
+	 *     ├── {@link #deserialiseMultipleInlineComments(List, UnsortedFileCommandContainer)}
+	 *     │   └── {@link #deserialiseInlineComment(String, FileCommandsInCommentList)}
+	 *     │       └── {@link #deserialiseFileCommandsInline(String, FileCommandsInCommentList)}
 	 *     ├── {@link #splitInputs(List, List, List, List, List, List)}
-	 *     │   └── {@link #deserialiseEndlineComment(String, List)}
-	 *     │       └── {@link #deserialiseFileCommandsEndline(String, List)}
+	 *     │   └── {@link #deserialiseEndlineComment(String, FileCommandsInCommentList)}
+	 *     │       └── {@link #deserialiseFileCommandsEndline(String, FileCommandsInCommentList)}
 	 *     ├── {@link #deserialiseKeyboard(List)}
 	 *     ├── {@link #deserialiseMouse(List)}
 	 *     └── {@link #deserialiseCameraAngle(List)}

--- a/src/main/java/com/minecrafttas/tasmod/playback/tasfile/flavor/SerialiserFlavorBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/tasfile/flavor/SerialiserFlavorBase.java
@@ -667,7 +667,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 		for (PlaybackFileCommand command : fileCommands) {
 			serialisedCommands.add(serialiseFileCommand(command));
 		}
-		return String.join(" ", serialisedCommands);
+		return joinNotEmpty(" ", serialisedCommands);
 	}
 
 	/**
@@ -698,7 +698,7 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 * @return The serialised file command, empty if {@link #processExtensions} is false
 	 */
 	protected String serialiseFileCommand(PlaybackFileCommand fileCommand) {
-		if (!processExtensions)
+		if (!processExtensions || fileCommand == null)
 			return "";
 		return String.format("$%s(%s);", fileCommand.getName(), String.join(", ", fileCommand.getArgs()));
 	}
@@ -1027,6 +1027,10 @@ public abstract class SerialiserFlavorBase implements Registerable {
 	 */
 	public BigArrayList<InputContainer> deserialise(BigArrayList<String> lines, long startPos) {
 		BigArrayList<InputContainer> out = new BigArrayList<>();
+
+		if (processExtensions)
+			TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.onClear();
+
 		for (long i = startPos; i < lines.size(); i++) {
 			List<String> container = new ArrayList<>();
 			// Extract the tick and set the index
@@ -1255,15 +1259,15 @@ public abstract class SerialiserFlavorBase implements Registerable {
 
 	protected void deserialiseMultipleInlineComments(List<String> inlineComments, UnsortedFileCommandContainer inlineFileCommands) {
 		for (int i = 0; i < inlineComments.size(); i++) {
-			FileCommandsInCommentList deserialisedFileCommand = new FileCommandsInCommentList();
+			FileCommandsInCommentList deserialisedFileCommands = new FileCommandsInCommentList();
 			String comment = inlineComments.get(i);
 
-			inlineComments.set(i, deserialiseInlineComment(comment, deserialisedFileCommand));
+			inlineComments.set(i, deserialiseInlineComment(comment, deserialisedFileCommands));
 
-			if (deserialisedFileCommand.isEmpty()) {
-				deserialisedFileCommand = null;
+			if (deserialisedFileCommands.isEmpty()) {
+				deserialisedFileCommands = null;
 			}
-			inlineFileCommands.add(deserialisedFileCommand);
+			inlineFileCommands.add(deserialisedFileCommands);
 		}
 	}
 

--- a/src/main/java/com/minecrafttas/tasmod/playback/tasfile/flavor/builtin/AlphaFlavor.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/tasfile/flavor/builtin/AlphaFlavor.java
@@ -20,6 +20,7 @@ import java.util.regex.Matcher;
 import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.FileCommandsInCommentList;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
 import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackLoadException;
 import com.minecrafttas.tasmod.playback.tasfile.flavor.SerialiserFlavorBase;
@@ -239,7 +240,7 @@ public class AlphaFlavor extends SerialiserFlavorBase {
 	}
 
 	@Override
-	protected String serialiseFileCommandsInline(List<PlaybackFileCommand> fileCommands) {
+	protected String serialiseFileCommandsInline(FileCommandsInCommentList fileCommands) {
 		if (fileCommands == null) {
 			return null;
 		}
@@ -256,7 +257,7 @@ public class AlphaFlavor extends SerialiserFlavorBase {
 	}
 
 	@Override
-	protected String serialiseFileCommandsEndline(List<PlaybackFileCommand> fileCommands) {
+	protected String serialiseFileCommandsEndline(FileCommandsInCommentList fileCommands) {
 		if (fileCommands == null) {
 			return null;
 		}
@@ -345,7 +346,7 @@ public class AlphaFlavor extends SerialiserFlavorBase {
 	}
 
 	@Override
-	protected String deserialiseFileCommandsInline(String comment, List<PlaybackFileCommand> deserialisedFileCommands) {
+	protected String deserialiseFileCommandsInline(String comment, FileCommandsInCommentList deserialisedFileCommands) {
 		Matcher matcher = extract("\\$(.+?) (.+?)", comment);
 
 		// Iterate through all file commands and add each to the list
@@ -371,7 +372,7 @@ public class AlphaFlavor extends SerialiserFlavorBase {
 	}
 
 	@Override
-	protected String deserialiseFileCommandsEndline(String comment, List<PlaybackFileCommand> deserialisedFileCommands) {
+	protected String deserialiseFileCommandsEndline(String comment, FileCommandsInCommentList deserialisedFileCommands) {
 		Matcher matcher = extract("Monitoring:(.+)", comment);
 
 		// Iterate through all file commands and add each to the list
@@ -528,7 +529,7 @@ public class AlphaFlavor extends SerialiserFlavorBase {
 	}
 
 	@Override
-	protected void deserialiseFileCommandNames(List<String> headerLines) {
+	protected void deserialiseEnabledFileCommandNames(List<String> headerLines) {
 		/*
 		 * Alpha has these file commands hardcoded
 		 */

--- a/src/test/java/tasmod/playback/filecommands/PlaybackFileCommandTest.java
+++ b/src/test/java/tasmod/playback/filecommands/PlaybackFileCommandTest.java
@@ -1,0 +1,163 @@
+package tasmod.playback.filecommands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.dselent.bigarraylist.BigArrayList;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.FileCommandsInCommentList;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.UnsortedFileCommandContainer;
+import com.minecrafttas.tasmod.registries.TASmodAPIRegistry;
+
+class PlaybackFileCommandTest {
+
+	class TestFileCommandExtension extends PlaybackFileCommandExtension {
+
+		public TestFileCommandExtension() {
+			enabled = true;
+		}
+
+		@Override
+		public String getExtensionName() {
+			return "tasmod_test@v1";
+		}
+
+		@Override
+		public String[] getFileCommandNames() {
+			return new String[] { "test" };
+		}
+
+		public BigArrayList<SortedFileCommandContainer> getInlineStorage() {
+			return this.inlineFileCommandStorage;
+		}
+
+		public BigArrayList<SortedFileCommandContainer> getEndlineStorage() {
+			return this.endlineFileCommandStorage;
+		}
+	}
+
+	class TestMultiFileCommandExtension extends PlaybackFileCommandExtension {
+
+		public TestMultiFileCommandExtension() {
+			enabled = true;
+		}
+
+		@Override
+		public String getExtensionName() {
+			return "tasmod_multi@v1";
+		}
+
+		@Override
+		public String[] getFileCommandNames() {
+			return new String[] { "multi1", "multi2" };
+		}
+
+		public BigArrayList<SortedFileCommandContainer> getInlineStorage() {
+			return this.inlineFileCommandStorage;
+		}
+
+		public BigArrayList<SortedFileCommandContainer> getEndlineStorage() {
+			return this.endlineFileCommandStorage;
+		}
+	}
+
+	TestFileCommandExtension test;
+	TestMultiFileCommandExtension multi;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		test = new TestFileCommandExtension();
+		multi = new TestMultiFileCommandExtension();
+		TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.register(test, multi);
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.clear();
+	}
+
+	@Test
+	void testInlineDeserialisation() {
+		// Actual
+		FileCommandsInCommentList list = new FileCommandsInCommentList();
+		list.add(new PlaybackFileCommand("test"));
+
+		UnsortedFileCommandContainer container = new UnsortedFileCommandContainer();
+		container.add(list);
+		TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnDeserialiseInline(0, null, container);
+
+		SortedFileCommandContainer actual = test.getInlineStorage().get(0);
+
+		// Expected
+		SortedFileCommandContainer expected = new SortedFileCommandContainer();
+		expected.add("test", new PlaybackFileCommand("test"));
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testEndlineDeserialisation() {
+		// Actual
+		FileCommandsInCommentList list = new FileCommandsInCommentList();
+		list.add(new PlaybackFileCommand("test"));
+
+		UnsortedFileCommandContainer container = new UnsortedFileCommandContainer();
+		container.add(list);
+		TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnDeserialiseEndline(0, null, container);
+
+		SortedFileCommandContainer actual = test.getEndlineStorage().get(0);
+
+		// Expected
+		SortedFileCommandContainer expected = new SortedFileCommandContainer();
+		expected.add("test", new PlaybackFileCommand("test"));
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testInline2LineDeserialisation() {
+		// Actual
+		FileCommandsInCommentList line1 = new FileCommandsInCommentList();
+		line1.add(new PlaybackFileCommand("test"));
+
+		UnsortedFileCommandContainer container = new UnsortedFileCommandContainer();
+		container.add(line1);
+		container.add(null);
+		TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnDeserialiseInline(0, null, container);
+
+		SortedFileCommandContainer actual = test.getInlineStorage().get(0);
+
+		// Expected
+		SortedFileCommandContainer expected = new SortedFileCommandContainer();
+		expected.add("test", new PlaybackFileCommand("test"));
+		expected.add("test", null);
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testMultiInlineDeserialisation() {
+		// Actual
+		FileCommandsInCommentList line1 = new FileCommandsInCommentList();
+		line1.add(new PlaybackFileCommand("multi1"));
+		line1.add(new PlaybackFileCommand("multi2"));
+
+		UnsortedFileCommandContainer container = new UnsortedFileCommandContainer();
+		container.add(line1);
+		TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnDeserialiseInline(0, null, container);
+
+		SortedFileCommandContainer actual = multi.getInlineStorage().get(0);
+
+		// Expected
+		SortedFileCommandContainer expected = new SortedFileCommandContainer();
+		expected.add("multi1", new PlaybackFileCommand("multi1"));
+		expected.add("multi2", new PlaybackFileCommand("multi2"));
+
+		assertEquals(expected, actual);
+	}
+}

--- a/src/test/java/tasmod/playback/filecommands/PlaybackFileCommandTest.java
+++ b/src/test/java/tasmod/playback/filecommands/PlaybackFileCommandTest.java
@@ -1,6 +1,7 @@
 package tasmod.playback.filecommands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -159,5 +160,74 @@ class PlaybackFileCommandTest {
 		expected.add("multi2", new PlaybackFileCommand("multi2"));
 
 		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testInlineSerialisation() {
+		// Actual
+		SortedFileCommandContainer container = new SortedFileCommandContainer();
+		container.add("test", new PlaybackFileCommand("test"));
+
+		test.getInlineStorage().add(container);
+
+		UnsortedFileCommandContainer actual = TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnSerialiseInline(0, null);
+
+		// Expected
+		UnsortedFileCommandContainer expected = new UnsortedFileCommandContainer();
+		FileCommandsInCommentList commentList = new FileCommandsInCommentList();
+
+		commentList.add(new PlaybackFileCommand("test"));
+		expected.add(commentList);
+
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testEndlineSerialisation() {
+		// Actual
+		SortedFileCommandContainer container = new SortedFileCommandContainer();
+		container.add("test", new PlaybackFileCommand("test"));
+
+		test.getEndlineStorage().add(container);
+
+		UnsortedFileCommandContainer actual = TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnSerialiseEndline(0, null);
+
+		// Expected
+		UnsortedFileCommandContainer expected = new UnsortedFileCommandContainer();
+		FileCommandsInCommentList commentList = new FileCommandsInCommentList();
+
+		commentList.add(new PlaybackFileCommand("test"));
+		expected.add(commentList);
+
+		assertIterableEquals(expected, actual);
+	}
+
+	@Test
+	void testMultiInlineSerialisation() {
+		// Actual
+		SortedFileCommandContainer container = new SortedFileCommandContainer();
+		container.add("multi1", new PlaybackFileCommand("multi1"));
+		container.add("multi1", null);
+
+		container.add("multi2", null);
+		container.add("multi2", new PlaybackFileCommand("multi2"));
+
+		multi.getInlineStorage().add(container);
+
+		UnsortedFileCommandContainer actual = TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.handleOnSerialiseInline(0, null);
+
+		// Expected
+		UnsortedFileCommandContainer expected = new UnsortedFileCommandContainer();
+		FileCommandsInCommentList commentList1 = new FileCommandsInCommentList();
+		FileCommandsInCommentList commentList2 = new FileCommandsInCommentList();
+
+		commentList1.add(new PlaybackFileCommand("multi1"));
+		commentList1.add(null);
+		commentList2.add(null);
+		commentList2.add(new PlaybackFileCommand("multi2"));
+		expected.add(commentList1);
+		expected.add(commentList2);
+
+		assertIterableEquals(expected, actual);
 	}
 }

--- a/src/test/java/tasmod/playback/tasfile/PlaybackSerialiserTest.java
+++ b/src/test/java/tasmod/playback/tasfile/PlaybackSerialiserTest.java
@@ -23,8 +23,8 @@ import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.CommentContainer;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata.PlaybackMetadataExtension;
 import com.minecrafttas.tasmod.playback.tasfile.PlaybackSerialiser;
@@ -89,22 +89,9 @@ public class PlaybackSerialiserTest {
 
 	private static class TestFileCommand extends PlaybackFileCommandExtension {
 
-		List<SortedFileCommandContainer> inline = new ArrayList<>();
-		List<SortedFileCommandContainer> endline = new ArrayList<>();
-
 		@Override
 		public String getExtensionName() {
 			return "tasmod_testFileExtension";
-		}
-
-		@Override
-		public void onDeserialiseInlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
-			inline.add(fileCommandContainer.split("testKey"));
-		}
-
-		@Override
-		public void onDeserialiseEndlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
-			endline.add(fileCommandContainer.split("endlineKey"));
 		}
 
 		@Override
@@ -112,10 +99,12 @@ public class PlaybackSerialiserTest {
 			return new String[] { "testKey", "endlineKey" };
 		}
 
-		@Override
-		public void onClear() {
-			inline.clear();
-			endline.clear();
+		public BigArrayList<SortedFileCommandContainer> getInlineStorage() {
+			return this.inlineFileCommandStorage;
+		}
+
+		public BigArrayList<SortedFileCommandContainer> getEndlineStorage() {
+			return this.endlineFileCommandStorage;
 		}
 	}
 
@@ -282,30 +271,26 @@ public class PlaybackSerialiserTest {
 
 		assertEquals("Wat", testMetadata.actual);
 
-		List<SortedFileCommandContainer> fclist = new ArrayList<>();
+		BigArrayList<SortedFileCommandContainer> fclist = new BigArrayList<>();
 		SortedFileCommandContainer fccontainer = new SortedFileCommandContainer();
 		fccontainer.add("testKey", new PlaybackFileCommand("testKey", "test"));
 
-		SortedFileCommandContainer fccontainerempty = new SortedFileCommandContainer();
-		fccontainerempty.put("testKey", null);
-
 		fclist.add(fccontainer);
-		fclist.add(fccontainerempty);
-		fclist.add(fccontainerempty);
-		assertIterableEquals(fclist, testFileCommand.inline);
+		fclist.add(new SortedFileCommandContainer());
+		fclist.add(new SortedFileCommandContainer());
+		assertBigArrayList(fclist, testFileCommand.getInlineStorage());
 
-		List<SortedFileCommandContainer> fclistEnd = new ArrayList<>();
+		BigArrayList<SortedFileCommandContainer> fclistEnd = new BigArrayList<>();
 		SortedFileCommandContainer fccontainerEnd = new SortedFileCommandContainer();
 		fccontainerEnd.add("endlineKey", null);
 		fccontainerEnd.add("endlineKey", new PlaybackFileCommand("endlineKey"));
-
-		SortedFileCommandContainer fccontainerEndEmpty = new SortedFileCommandContainer();
-		fccontainerEndEmpty.put("endlineKey", null);
+		fccontainerEnd.add("testKey", null);
+		fccontainerEnd.add("testKey", new PlaybackFileCommand("testKey"));
 
 		fclistEnd.add(fccontainerEnd);
-		fclistEnd.add(fccontainerEndEmpty);
-		fclistEnd.add(fccontainerEndEmpty);
-		assertIterableEquals(fclistEnd, testFileCommand.endline);
+		fclistEnd.add(new SortedFileCommandContainer());
+		fclistEnd.add(new SortedFileCommandContainer());
+		assertBigArrayList(fclistEnd, testFileCommand.getEndlineStorage());
 	}
 
 	@Test
@@ -372,8 +357,8 @@ public class PlaybackSerialiserTest {
 
 		assertEquals("e", testMetadata.actual);
 
-		assertTrue(testFileCommand.inline.isEmpty());
-		assertTrue(testFileCommand.endline.isEmpty());
+		assertTrue(testFileCommand.getInlineStorage().isEmpty());
+		assertTrue(testFileCommand.getEndlineStorage().isEmpty());
 	}
 
 	@Test

--- a/src/test/java/tasmod/playback/tasfile/PlaybackSerialiserTest.java
+++ b/src/test/java/tasmod/playback/tasfile/PlaybackSerialiserTest.java
@@ -23,7 +23,7 @@ import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.CommentContainer;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
-import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandContainer;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata.PlaybackMetadataExtension;
@@ -89,8 +89,8 @@ public class PlaybackSerialiserTest {
 
 	private static class TestFileCommand extends PlaybackFileCommandExtension {
 
-		List<PlaybackFileCommandContainer> inline = new ArrayList<>();
-		List<PlaybackFileCommandContainer> endline = new ArrayList<>();
+		List<SortedFileCommandContainer> inline = new ArrayList<>();
+		List<SortedFileCommandContainer> endline = new ArrayList<>();
 
 		@Override
 		public String getExtensionName() {
@@ -98,12 +98,12 @@ public class PlaybackSerialiserTest {
 		}
 
 		@Override
-		public void onDeserialiseInlineComment(long tick, InputContainer container, PlaybackFileCommandContainer fileCommandContainer) {
+		public void onDeserialiseInlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
 			inline.add(fileCommandContainer.split("testKey"));
 		}
 
 		@Override
-		public void onDeserialiseEndlineComment(long tick, InputContainer container, PlaybackFileCommandContainer fileCommandContainer) {
+		public void onDeserialiseEndlineComment(long tick, InputContainer container, SortedFileCommandContainer fileCommandContainer) {
 			endline.add(fileCommandContainer.split("endlineKey"));
 		}
 
@@ -282,11 +282,11 @@ public class PlaybackSerialiserTest {
 
 		assertEquals("Wat", testMetadata.actual);
 
-		List<PlaybackFileCommandContainer> fclist = new ArrayList<>();
-		PlaybackFileCommandContainer fccontainer = new PlaybackFileCommandContainer();
+		List<SortedFileCommandContainer> fclist = new ArrayList<>();
+		SortedFileCommandContainer fccontainer = new SortedFileCommandContainer();
 		fccontainer.add("testKey", new PlaybackFileCommand("testKey", "test"));
 
-		PlaybackFileCommandContainer fccontainerempty = new PlaybackFileCommandContainer();
+		SortedFileCommandContainer fccontainerempty = new SortedFileCommandContainer();
 		fccontainerempty.put("testKey", null);
 
 		fclist.add(fccontainer);
@@ -294,12 +294,12 @@ public class PlaybackSerialiserTest {
 		fclist.add(fccontainerempty);
 		assertIterableEquals(fclist, testFileCommand.inline);
 
-		List<PlaybackFileCommandContainer> fclistEnd = new ArrayList<>();
-		PlaybackFileCommandContainer fccontainerEnd = new PlaybackFileCommandContainer();
+		List<SortedFileCommandContainer> fclistEnd = new ArrayList<>();
+		SortedFileCommandContainer fccontainerEnd = new SortedFileCommandContainer();
 		fccontainerEnd.add("endlineKey", null);
 		fccontainerEnd.add("endlineKey", new PlaybackFileCommand("endlineKey"));
 
-		PlaybackFileCommandContainer fccontainerEndEmpty = new PlaybackFileCommandContainer();
+		SortedFileCommandContainer fccontainerEndEmpty = new SortedFileCommandContainer();
 		fccontainerEndEmpty.put("endlineKey", null);
 
 		fclistEnd.add(fccontainerEnd);

--- a/src/test/java/tasmod/playback/tasfile/SerialiserFlavorBaseTest.java
+++ b/src/test/java/tasmod/playback/tasfile/SerialiserFlavorBaseTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.api.Test;
 import com.dselent.bigarraylist.BigArrayList;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.FileCommandsInCommentList;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
+import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.UnsortedFileCommandContainer;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
 import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata.PlaybackMetadataExtension;
 import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackLoadException;
@@ -184,7 +186,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.setEnabled("tasmod_testFileCommand", true);
 
 		List<String> actual = new ArrayList<>();
-		serialiseFileCommandNames(actual);
+		serialiseEnabledFileCommandNames(actual);
 
 		List<String> expected = new ArrayList<>();
 		expected.add("FileCommand-Extensions: tasmod_testFileCommand");
@@ -244,7 +246,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		inlineComments.add("Test2");
 		inlineComments.add(""); // Should result in "// "
 
-		List<String> actual = serialiseInlineComments(inlineComments, new ArrayList<>());
+		List<String> actual = serialiseInlineComments(inlineComments, new UnsortedFileCommandContainer());
 
 		List<String> expected = new ArrayList<>();
 		expected.add("// Test");
@@ -262,18 +264,18 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 
 	@Test
 	void testSerialiseFileCommands() {
-		List<List<PlaybackFileCommand>> fileCommands = new ArrayList<>();
-		List<PlaybackFileCommand> fcInLine = new ArrayList<>();
+		UnsortedFileCommandContainer fileCommands = new UnsortedFileCommandContainer();
+		FileCommandsInCommentList fcInLine = new FileCommandsInCommentList();
 		fcInLine.add(new PlaybackFileCommand("test"));
 		fcInLine.add(new PlaybackFileCommand("testing2", "true", "false"));
 
-		List<PlaybackFileCommand> fcInLine2 = new ArrayList<>();
+		FileCommandsInCommentList fcInLine2 = new FileCommandsInCommentList();
 		fcInLine2.add(new PlaybackFileCommand("interpolation", "true"));
 
 		fileCommands.add(fcInLine);
 		fileCommands.add(null);
 		fileCommands.add(fcInLine2);
-		fileCommands.add(new ArrayList<>());
+		fileCommands.add(new FileCommandsInCommentList());
 
 		List<String> actual = serialiseInlineComments(null, fileCommands);
 
@@ -288,22 +290,22 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 
 	@Test
 	void testMergingCommentsAndCommands() {
-		List<List<PlaybackFileCommand>> fileCommands = new ArrayList<>();
-		List<PlaybackFileCommand> fcInLine = new ArrayList<>();
+		UnsortedFileCommandContainer fileCommands = new UnsortedFileCommandContainer();
+		FileCommandsInCommentList fcInLine = new FileCommandsInCommentList();
 		fcInLine.add(new PlaybackFileCommand("test"));
 		fcInLine.add(new PlaybackFileCommand("testing2", "true", "false"));
 
 		fileCommands.add(fcInLine);
 		fileCommands.add(null);
 		fileCommands.add(null);
-		fileCommands.add(new ArrayList<>());
+		fileCommands.add(new FileCommandsInCommentList());
 
-		List<PlaybackFileCommand> fcInLine2 = new ArrayList<>();
+		FileCommandsInCommentList fcInLine2 = new FileCommandsInCommentList();
 		fcInLine2.add(new PlaybackFileCommand("interpolation", "true"));
 
 		fileCommands.add(fcInLine2);
 
-		List<PlaybackFileCommand> fcInLine3 = new ArrayList<>();
+		FileCommandsInCommentList fcInLine3 = new FileCommandsInCommentList();
 		fcInLine3.add(new PlaybackFileCommand("info", "Scribble"));
 		fcInLine3.add(new PlaybackFileCommand("info", "Dribble"));
 
@@ -521,7 +523,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		List<String> lines = new ArrayList<>();
 		lines.add("FileCommand-Extensions: tasmod_test1, tasmod_test2");
 
-		deserialiseFileCommandNames(lines);
+		deserialiseEnabledFileCommandNames(lines);
 
 		assertTrue(test1.isEnabled());
 		assertTrue(test2.isEnabled());
@@ -529,7 +531,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		lines = new ArrayList<>();
 		lines.add("FileCommand-Extensions: ");
 
-		deserialiseFileCommandNames(lines);
+		deserialiseEnabledFileCommandNames(lines);
 
 		assertFalse(test1.isEnabled());
 		assertFalse(test2.isEnabled());
@@ -537,7 +539,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		lines = new ArrayList<>();
 		lines.add("FileCommand-Extensions: tasmod_test1,tasmod_test2");
 
-		deserialiseFileCommandNames(lines);
+		deserialiseEnabledFileCommandNames(lines);
 
 		assertTrue(test1.isEnabled());
 		assertTrue(test2.isEnabled());
@@ -546,7 +548,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		lines2.add("FileCommand-Extensions tasmod_test1,tasmod_test2");
 
 		Throwable t = assertThrows(PlaybackLoadException.class, () -> {
-			deserialiseFileCommandNames(lines2);
+			deserialiseEnabledFileCommandNames(lines2);
 		});
 
 		assertEquals("FileCommand-Extensions value was not found in the header", t.getMessage());
@@ -729,7 +731,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		List<String> actualMouse = new ArrayList<>();
 		List<String> actualCameraAngle = new ArrayList<>();
 		List<String> actualComment = new ArrayList<>();
-		List<List<PlaybackFileCommand>> actualFileCommand = new ArrayList<>();
+		UnsortedFileCommandContainer actualFileCommand = new UnsortedFileCommandContainer();
 
 		splitInputs(tick, actualKeyboard, actualMouse, actualCameraAngle, actualComment, actualFileCommand);
 
@@ -737,7 +739,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		List<String> expectedMouse = new ArrayList<>();
 		List<String> expectedCameraAngle = new ArrayList<>();
 		List<String> expectedComment = new ArrayList<>();
-		List<List<PlaybackFileCommand>> expectedFileCommand = new ArrayList<>();
+		UnsortedFileCommandContainer expectedFileCommand = new UnsortedFileCommandContainer();
 
 		expectedKeyboard.add("W,LCONTROL;w");
 
@@ -756,7 +758,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		expectedFileCommand.add(null);
 		expectedFileCommand.add(null);
 
-		List<PlaybackFileCommand> lineCommand = new ArrayList<>();
+		FileCommandsInCommentList lineCommand = new FileCommandsInCommentList();
 		lineCommand.add(new PlaybackFileCommand("test", "true"));
 
 		expectedFileCommand.add(lineCommand);
@@ -784,7 +786,7 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		List<String> actualTick = new ArrayList<>();
 		splitContainer(lines, actualComments, actualTick);
 
-		List<List<PlaybackFileCommand>> actualInlineFileCommands = new ArrayList<>();
+		UnsortedFileCommandContainer actualInlineFileCommands = new UnsortedFileCommandContainer();
 		deserialiseMultipleInlineComments(actualComments, actualInlineFileCommands);
 
 		List<String> expectedComments = new ArrayList<>();
@@ -796,8 +798,8 @@ public class SerialiserFlavorBaseTest extends SerialiserFlavorBase {
 		expectedTicks.add("\t1||RC;-15,1580,658|11.85;-2.74799");
 		expectedTicks.add("\t2||;0,1580,658|45;-22.799");
 
-		List<List<PlaybackFileCommand>> expectedInlineFileCommands = new ArrayList<>();
-		List<PlaybackFileCommand> commands = new ArrayList<>();
+		UnsortedFileCommandContainer expectedInlineFileCommands = new UnsortedFileCommandContainer();
+		FileCommandsInCommentList commands = new FileCommandsInCommentList();
 		commands.add(new PlaybackFileCommand("interpolation", "on"));
 		expectedInlineFileCommands.add(commands);
 		expectedInlineFileCommands.add(null);

--- a/src/test/java/tasmod/playback/tasfile/builtin/AlphaFlavorTest.java
+++ b/src/test/java/tasmod/playback/tasfile/builtin/AlphaFlavorTest.java
@@ -210,7 +210,7 @@ public class AlphaFlavorTest extends AlphaFlavor {
 
 	@Test
 	void testDeserialiseFileCommandNames() {
-		deserialiseFileCommandNames(new ArrayList<>());
+		deserialiseEnabledFileCommandNames(new ArrayList<>());
 
 		List<PlaybackFileCommandExtension> fcList = TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.getEnabled();
 		assertTrue(fcList.get(0) instanceof LabelFileCommandExtension);


### PR DESCRIPTION
## Refactor
Filecommands have some overengineered data sorting built in, when using them in the serilialiser vs. using them during playback.

To better visualise this, I created 2 seperate "containers", unsorted and sorted which are used in serialising and playback respectively. 

Additionally, I used an `ArrrayList<PlaybackSerialiser>` in both containers, but the format in this list is actually different and this lead to a lot of confusion while trying to figure out my own code...  
So instead, I added 2 classes that extend `ArrrayList<PlaybackSerialiser>` called FileCommandsInCommentList and FileCommandsInTickList to better visualize the format and to add documentation... Which should hopefully make this less confusing...

## Fixes
- Fixes #231 