### PR TITLE
Various multiplayer fixes

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -39,6 +39,7 @@ import com.minecrafttas.tasmod.registries.TASmodConfig;
 import com.minecrafttas.tasmod.registries.TASmodKeybinds;
 import com.minecrafttas.tasmod.registries.TASmodPackets;
 import com.minecrafttas.tasmod.savestates.SavestateHandlerClient;
+import com.minecrafttas.tasmod.savestates.handlers.SavestatePlayerHandler;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerClient;
 import com.minecrafttas.tasmod.ticksync.TickSyncClient;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
@@ -169,6 +170,7 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		PacketHandlerRegistry.register(ticksyncClient);
 		PacketHandlerRegistry.register(tickratechanger);
 		PacketHandlerRegistry.register(savestateHandlerClient);
+		PacketHandlerRegistry.register(new SavestatePlayerHandler(null)); //TODO Split player handler into client and server
 	}
 
 	private void registerEventListeners() {

--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerClient.java
@@ -222,7 +222,7 @@ public class SavestateHandlerClient implements ClientPacketHandler, EventSavesta
 			 * 
 			 * We expect to start at tick 10 WITHOUT clearing the controller.
 			 * If we were to replace the controller, everything above tick 10 would be lost.
-			 * So we only set the index to 10, preload and preload the inputs.
+			 * So we only set the index to 10 and preload the inputs.
 			 * 
 			 *            VV
 			 *  0         10       20

--- a/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestatePlayerHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestatePlayerHandler.java
@@ -152,7 +152,6 @@ public class SavestatePlayerHandler implements ClientPacketHandler, ServerPacket
 	public void changeDimensionDangerously(EntityPlayerMP player, int dimensionTo) {
 		int dimensionFrom = player.dimension;
 		WorldServer worldServerFrom = this.server.getWorld(dimensionFrom);
-//		WorldServer worldServerTo = this.server.getWorld(dimensionTo);
 
 		//@formatter:off
 		player.connection
@@ -167,10 +166,6 @@ public class SavestatePlayerHandler implements ClientPacketHandler, ServerPacket
 		//@formatter:on
 		worldServerFrom.removeEntityDangerously(player);
 		player.isDead = false;
-//		worldServerTo.spawnEntity(player);
-//		worldServerTo.updateEntityWithOptionalForce(player, false);
-//		player.setWorld(worldServerTo);
-//		player.interactionManager.setWorld(worldServerTo);
 	}
 
 	public void clearScoreboard() {

--- a/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestatePlayerHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestatePlayerHandler.java
@@ -112,6 +112,10 @@ public class SavestatePlayerHandler implements ClientPacketHandler, ServerPacket
 
 			NBTTagCompound nbttagcompound = server.getPlayerList().readPlayerDataFromFile(player);
 
+			if (nbttagcompound == null) {
+				continue;
+			}
+
 			int dimensionTo = 0;
 			if (nbttagcompound.hasKey("Dimension")) {
 				dimensionTo = nbttagcompound.getInteger("Dimension");
@@ -210,7 +214,7 @@ public class SavestatePlayerHandler implements ClientPacketHandler, ServerPacket
 					compound = TASmodBufferBuilder.readNBTTagCompound(buf);
 				} catch (IOException e) {
 					e.printStackTrace();
-					return;
+					break;
 				}
 				/*
 				 * Fair warning: Do NOT read the buffer inside an addScheduledTask. Read it

--- a/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerServer.java
@@ -5,7 +5,7 @@ import java.nio.ByteBuffer;
 import org.apache.logging.log4j.Logger;
 
 import com.minecrafttas.mctcommon.events.EventListenerRegistry;
-import com.minecrafttas.mctcommon.events.EventServer.EventPlayerJoinedServerSide;
+import com.minecrafttas.mctcommon.events.EventServer.EventClientCompleteAuthentication;
 import com.minecrafttas.mctcommon.events.EventServer.EventServerStop;
 import com.minecrafttas.mctcommon.networking.Client.Side;
 import com.minecrafttas.mctcommon.networking.exception.PacketNotImplementedException;
@@ -18,7 +18,6 @@ import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
 import com.minecrafttas.tasmod.registries.TASmodPackets;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 
 /**
@@ -39,7 +38,7 @@ import net.minecraft.server.MinecraftServer;
  * @author Scribble
  *
  */
-public class TickrateChangerServer implements EventServerStop, EventPlayerJoinedServerSide, ServerPacketHandler {
+public class TickrateChangerServer implements EventServerStop, EventClientCompleteAuthentication, ServerPacketHandler {
 
 	/**
 	 * The current tickrate of the client
@@ -208,12 +207,12 @@ public class TickrateChangerServer implements EventServerStop, EventPlayerJoined
 	 * @param player The player that joins the server
 	 */
 	@Override
-	public void onPlayerJoinedServerSide(EntityPlayerMP player) {
+	public void onClientCompleteAuthentication(String username) {
 		if (TASmod.getServerInstance().isDedicatedServer()) {
-			log("Sending the current tickrate (" + ticksPerSecond + ") to " + player.getName());
+			log("Sending the current tickrate (" + ticksPerSecond + ") to " + username);
 
 			try {
-				TASmod.server.sendTo(player, new TASmodBufferBuilder(TASmodPackets.TICKRATE_CHANGE).writeFloat(ticksPerSecond));
+				TASmod.server.sendTo(username, new TASmodBufferBuilder(TASmodPackets.TICKRATE_CHANGE).writeFloat(ticksPerSecond));
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
@@ -292,5 +291,4 @@ public class TickrateChangerServer implements EventServerStop, EventPlayerJoined
 				throw new PacketNotImplementedException(packet, this.getClass(), Side.SERVER);
 		}
 	}
-
 }

--- a/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/tickratechanger/TickrateChangerServer.java
@@ -208,7 +208,7 @@ public class TickrateChangerServer implements EventServerStop, EventClientComple
 	 */
 	@Override
 	public void onClientCompleteAuthentication(String username) {
-		if (TASmod.getServerInstance().isDedicatedServer()) {
+		if (TASmod.getServerInstance() != null && TASmod.getServerInstance().isDedicatedServer()) {
 			log("Sending the current tickrate (" + ticksPerSecond + ") to " + username);
 
 			try {


### PR DESCRIPTION
- [Tickrate] Fixed initial tickrate not being sent, when a player joins the server
- [Savestate] Fixed savestates failing when player does not have playerdata
- [Savestate] Fixed player not getting motion applied in multiplayer