### PR TITLE
[Keybinds] Fix TASmod keybinds resetting when restarting the game

### DIFF
--- a/src/main/java/com/minecrafttas/mctcommon/KeybindManager.java
+++ b/src/main/java/com/minecrafttas/mctcommon/KeybindManager.java
@@ -92,13 +92,12 @@ public class KeybindManager implements EventClientGameLoop {
 	 * Register new keybind
 	 * 
 	 * @param keybind Keybind to register
+	 * @param options 
 	 */
-	public void registerKeybind(Keybind keybind) {
+	public void registerKeybind(Keybind keybind, GameSettings options) {
 		this.keybindings.add(keybind);
 		KeyBinding keyBinding = keybind.vanillaKeyBinding;
 
-		// add category
-		GameSettings options = Minecraft.getMinecraft().gameSettings;
 		if (!AccessorKeyBinding.getCategoryOrder().containsKey(keybind.category))
 			AccessorKeyBinding.getCategoryOrder().put(keybind.category, AccessorKeyBinding.getCategoryOrder().size() + 1);
 

--- a/src/main/java/com/minecrafttas/mctcommon/events/EventClient.java
+++ b/src/main/java/com/minecrafttas/mctcommon/events/EventClient.java
@@ -8,6 +8,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.client.settings.GameSettings;
 
 /**
  * Contains all events fired on the client side
@@ -217,5 +218,17 @@ public interface EventClient {
 		 * @param client The client that is disconnecting
 		 */
 		public void onDisconnectClient(Client client);
+	}
+
+	/**
+	 * Fired just before the vanilla options are loaded from the file
+	 */
+	@FunctionalInterface
+	public static interface EventOptionsInit extends EventBase {
+
+		/**
+		 * Fired just before the vanilla options are loaded from the file
+		 */
+		public void onOptionsInit(GameSettings options);
 	}
 }

--- a/src/main/java/com/minecrafttas/mctcommon/mixin/MixinGameSettings.java
+++ b/src/main/java/com/minecrafttas/mctcommon/mixin/MixinGameSettings.java
@@ -1,0 +1,20 @@
+package com.minecrafttas.mctcommon.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.minecrafttas.mctcommon.events.EventClient;
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
+
+import net.minecraft.client.settings.GameSettings;
+
+@Mixin(GameSettings.class)
+public class MixinGameSettings {
+
+	@Inject(method = "loadOptions", at = @At("HEAD"))
+	public void events_loadOptions(CallbackInfo ci) {
+		EventListenerRegistry.fireEvent(EventClient.EventOptionsInit.class, (GameSettings) (Object) this);
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -16,6 +16,7 @@ import com.minecrafttas.mctcommon.KeybindManager;
 import com.minecrafttas.mctcommon.LanguageManager;
 import com.minecrafttas.mctcommon.events.EventClient.EventClientInit;
 import com.minecrafttas.mctcommon.events.EventClient.EventOpenGui;
+import com.minecrafttas.mctcommon.events.EventClient.EventOptionsInit;
 import com.minecrafttas.mctcommon.events.EventClient.EventPlayerJoinedClientSide;
 import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import com.minecrafttas.mctcommon.file.AbstractDataFile;
@@ -55,9 +56,10 @@ import net.minecraft.client.gui.GuiControls;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.server.MinecraftServer;
 
-public class TASmodClient implements ClientModInitializer, EventClientInit, EventPlayerJoinedClientSide, EventOpenGui {
+public class TASmodClient implements ClientModInitializer, EventClientInit, EventPlayerJoinedClientSide, EventOpenGui, EventOptionsInit {
 
 	public static VirtualInput virtual;
 
@@ -200,7 +202,6 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 
 	@Override
 	public void onClientInit(Minecraft mc) {
-		registerKeybindings(mc);
 		registerPlaybackMetadata(mc);
 		registerSerialiserFlavors(mc);
 		registerFileCommands();
@@ -308,8 +309,9 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		}
 	}
 
-	private void registerKeybindings(Minecraft mc) {
-		Arrays.stream(TASmodKeybinds.valuesKeybind()).forEach(keybindManager::registerKeybind);
+	@Override
+	public void onOptionsInit(GameSettings options) {
+		Arrays.stream(TASmodKeybinds.valuesKeybind()).forEach((keybind) -> keybindManager.registerKeybind(keybind, options));
 		Arrays.stream(TASmodKeybinds.valuesVanillaKeybind()).forEach(VirtualKeybindings::registerBlockedKeyBinding);
 	}
 

--- a/src/main/resources/mctcommon.mixin.json
+++ b/src/main/resources/mctcommon.mixin.json
@@ -12,6 +12,7 @@
     	"MixinMinecraft",
     	"MixinNetHandlerPlayClient",
     	"MixinWorldClient",
-        "MixinLocale"
+        "MixinLocale",
+		"MixinGameSettings"
 	]
 }


### PR DESCRIPTION
Adds a new event "EventOptionsInit" that fires just before the options load from the file.