### PR TITLE
[Savestates] Attempt at fixing velocity being reset on loadstate

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateWorldHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateWorldHandler.java
@@ -157,7 +157,8 @@ public class SavestateWorldHandler {
 		} else {
 			playerChunkMap.addPlayer(player);
 		}
-		world.getChunkProvider().provideChunk(playerChunkPosX, playerChunkPosY);
+		Chunk chunk = world.getChunkProvider().provideChunk(playerChunkPosX, playerChunkPosY);
+		chunk.addEntity(player);
 
 		world.spawnEntity(player);
 	}
@@ -239,7 +240,6 @@ public class SavestateWorldHandler {
 			}
 
 			server.worlds[i].addEventListener(new ServerWorldEventHandler(server, server.worlds[i]));
-			server.worlds[i].tick();	// TODO I give up...
 		}
 
 		server.getPlayerList().setPlayerManager(server.worlds);


### PR DESCRIPTION
One tick after a loadstate, the velocity of the player will be reset for one tick, which desyncs the rest of the TAS.

I was able to trace the issue back to the NetHandlerPlayServer, where the player is processed. If the player is not added to the chunk on the server side, a collision check with the nearest block would fail (kinda like walking into unloaded chunks) and the velocity would be reset to 0, which would then get sent to the client.

To fix this, I add the player to yet another chunk variable. Hopefully this will not bite me in the future