### PR TITLE
[Serialiser] Fix some inputs sometimes not being saved

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/util/FileThread.java
+++ b/src/main/java/com/minecrafttas/tasmod/util/FileThread.java
@@ -8,8 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Thread for writing files to disc
@@ -21,32 +20,33 @@ public class FileThread extends Thread {
 	private final PrintWriter stream;
 	private boolean end = false;
 
-	private final List<String> output = new ArrayList<>();
+	private final ConcurrentLinkedQueue<String> output = new ConcurrentLinkedQueue<>();
 
 	public FileThread(Path fileLocation, boolean append) throws IOException {
+		super("TASmod FileWriter Thread");
 		OutputStream outStream = Files.newOutputStream(fileLocation, StandardOpenOption.CREATE, append ? StandardOpenOption.APPEND : StandardOpenOption.TRUNCATE_EXISTING);
-		stream = new PrintWriter(new OutputStreamWriter(outStream, StandardCharsets.UTF_8));
+		stream = new PrintWriter(new OutputStreamWriter(outStream, StandardCharsets.UTF_8), true);
 	}
 
 	public void addLine(String line) {
-		synchronized (output) {
-			output.add(line + "\n");
-		}
+		output.add(line + "\n");
 	}
 
 	@Override
 	public void run() {
 		while (!end) {
-			synchronized (output) {
-				ArrayList<String> newList = new ArrayList<String>(output);
-				output.clear();
-				for (String line : newList) {
-					stream.print(line);
-				}
-			}
+			writeOutput();
 		}
+		writeOutput();		// Print any remaining lines, just to be safe...
+
 		stream.flush();
 		stream.close();
+	}
+
+	private void writeOutput() {
+		String line;
+		while ((line = output.poll()) != null)
+			stream.print(line);
 	}
 
 	public void close() {


### PR DESCRIPTION
Fixed a race condition in the FileThread that
prevents some inputs at the end of the file not getting serialised.

Switched the collection type from an arraylist to a queue and added an extra safety writeOutput, after the thread is closed