### PR TITLE
[PlayUntil] Fixed playuntil, attempt 2

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/handlers/PlayUntilHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/handlers/PlayUntilHandler.java
@@ -35,12 +35,11 @@ public class PlayUntilHandler implements ClientPacketHandler, ServerPacketHandle
 		if (playUntil != null && playUntil == index) {
 			TASmodClient.tickratechanger.pauseGame(true);
 			PlaybackControllerClient controller = TASmodClient.controller;
-			controller.setTASState(TASstate.NONE);
+			controller.setTASState(TASstate.RECORDING);
 			controller.setIndex(controller.index() - 1);
 			for (long i = controller.size() - 1; i >= index; i--) {
 				controller.remove(i);
 			}
-			controller.setTASState(TASstate.RECORDING);
 			playUntil = null;
 		}
 	}

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -237,7 +237,10 @@ public class PlaybackControllerClient implements
 				case PLAYBACK:
 					return TextFormatting.RED + "Please report this message to the mod author, because you should never be able to see this (Error: Playback)";
 				case RECORDING:
-					return verbose ? TextFormatting.RED + "A playback is currently running. Please stop the playback first before starting a recording" : "";
+					stopPlayback(false);
+					startRecording();
+					state = TASstate.RECORDING;
+					return verbose ? TextFormatting.GREEN + "Switching from playback to recording" : "";
 				case PAUSED:
 					LOGGER.debug(LoggerMarkers.Playback, "Pausing a playback");
 					state = TASstate.PAUSED;
@@ -245,7 +248,7 @@ public class PlaybackControllerClient implements
 					TASmodClient.virtual.clear();
 					return verbose ? TextFormatting.GREEN + "Pausing a playback" : "";
 				case NONE:
-					stopPlayback();
+					stopPlayback(true);
 					state = TASstate.NONE;
 					return verbose ? TextFormatting.GREEN + "Stopping the playback" : "";
 			}
@@ -298,10 +301,12 @@ public class PlaybackControllerClient implements
 //		TASmod.ktrngHandler.setInitialSeed(startSeed);
 	}
 
-	private void stopPlayback() {
+	private void stopPlayback(boolean clearInputs) {
 		LOGGER.debug(LoggerMarkers.Playback, "Stopping a playback");
 		Minecraft.getMinecraft().gameSettings.chatLinks = true;
-		TASmodClient.virtual.clear();
+		if (clearInputs) {
+			TASmodClient.virtual.clear();
+		}
 	}
 
 	/**

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -466,6 +466,10 @@ public class PlaybackControllerClient implements
 		} else if (state == TASstate.PLAYBACK) {
 			playbackNextTick();
 		}
+
+//		if (TASmod.isDevEnvironment) {
+//			DebugWriter.writeDebugFile(this);
+//		}
 	}
 
 	private void recordNextTick() {

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerServer.java
@@ -88,7 +88,7 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 
 	public void setServerState(TASstate stateIn) {
 		if (state != stateIn) {
-			if (state == TASstate.RECORDING && stateIn == TASstate.PLAYBACK || state == TASstate.PLAYBACK && stateIn == TASstate.RECORDING)
+			if (state == TASstate.RECORDING && stateIn == TASstate.PLAYBACK)
 				return;
 			if (state == TASstate.NONE && state == TASstate.PAUSED) {
 				return;

--- a/src/main/java/com/minecrafttas/tasmod/util/DebugWriter.java
+++ b/src/main/java/com/minecrafttas/tasmod/util/DebugWriter.java
@@ -1,0 +1,21 @@
+package com.minecrafttas.tasmod.util;
+
+import java.nio.file.Path;
+
+import com.minecrafttas.tasmod.TASmodClient;
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient;
+import com.minecrafttas.tasmod.playback.tasfile.PlaybackSerialiser;
+
+/**
+ * Prints the current {@link PlaybackControllerClient#inputs} content to {@link TASmodClient#tasfiledirectory}/debug.mctas
+ * 
+ * @author Scribble
+ */
+public class DebugWriter {
+
+	private static Path debugTASFile = TASmodClient.tasfiledirectory.resolve("debug.mctas");
+
+	public static void writeDebugFile(PlaybackControllerClient controller) {
+		PlaybackSerialiser.saveToFile(debugTASFile, controller, null);
+	}
+}


### PR DESCRIPTION
Previously, I made it so that if you are currently playing back the inputs, setting the state to recording would just throw an error. Now I am changing it to allow you to switch from playback to recording, which also doesn't clear the current inputs anymore.

- Added a way to constantly write the current PlaybackController inputs to the file for debugging inputs.