### PR TITLE
[Savestates] Fix bossbars not being cleared on loadstate

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerClient.java
@@ -330,6 +330,9 @@ public class SavestateHandlerClient implements ClientPacketHandler, EventSavesta
 		SubtickDuck entityRenderer = (SubtickDuck) Minecraft.getMinecraft().entityRenderer;
 		entityRenderer.runUpdate(0);
 
+		// Clear boss bars on savestate load
+		mc.ingameGUI.getBossOverlay().clearBossInfos();
+
 		EventListenerRegistry.fireEvent(EventSavestate.EventClientLoadPlayer.class, player);
 	}
 


### PR DESCRIPTION
Cleared all boss bars on savestate load on the client. They will be readded automatically when a boss appears

Fixes #219 