### PR TITLE
[Savestates] Fixed index being set to 0 when using fullplay

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
@@ -239,7 +239,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		server.getPlayerList().sendMessage(new TextComponentString(TextFormatting.GREEN + "Savestate " + indexToSave + " saved"));
 
 		try {
-			// close GuiSavestateScreen
+			// Close GuiSavestateScreen
 			TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.CLEAR_SCREEN));
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -700,8 +700,10 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 			file.load(savestateDat);
 
 			index = Integer.parseInt(file.get(DataValues.INDEX));
-
-			setCurrentIndex(index);
+			if (index != 0)
+				setCurrentIndex(index);
+			else
+				setCurrentIndex(latestIndex);
 		}
 	}
 


### PR DESCRIPTION
This is a temporary fix until the indexing system is reworked... 
My plan is to use the indexing system from LoTAS-Light at some point, where this issue is fixed...

Sets the index to the latest index instead of 0 when savestate 0 is loaded. Not ideal, but this minimizes the chance of accidentally overwriting something.