### PR TITLE
[Keybinds] Add secret keybinds that turn the camera 45° left/right

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/registries/TASmodKeybinds.java
+++ b/src/main/java/com/minecrafttas/tasmod/registries/TASmodKeybinds.java
@@ -38,7 +38,12 @@ public enum TASmodKeybinds {
 			mc.displayGuiScreen(TASmodClient.hud);
 		}
 	}),
-
+	TURN_LEFT("Rotate 45 degrees left", "TASmod", Keyboard.KEY_NONE, () -> {
+		TASmodClient.virtual.CAMERA_ANGLE.updateNextCameraAngle(0, -45);
+	}),
+	TURN_RIGHT("Rotate 45 degrees right", "TASmod", Keyboard.KEY_NONE, () -> {
+		TASmodClient.virtual.CAMERA_ANGLE.updateNextCameraAngle(0, 45);
+	}),
 	TEST1("Various Testing", "TASmod", Keyboard.KEY_F12, () -> {
 	}, VirtualKeybindings::isKeyDown),
 	TEST2("Various Testing2", "TASmod", Keyboard.KEY_F7, () -> {


### PR DESCRIPTION
This feature request comes from ACatThatCanParkourReallyWell9900 and I agree that getting 45° strafe right now is pretty tedious... Until a proper gui with buttons is made, keybinds will have to do for accessing this functionality...

Currently the keybinds are not set, as to not have too many keybinds that overwhelm the player...