### PR TITLE
[PlaybackController] Fix restartandplay not working

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -157,6 +157,7 @@ public class TASmod implements ModInitializer, EventServerInit, EventServerStop 
 		savestateHandlerServer = new SavestateHandlerServer(server, LOGGER);
 		PacketHandlerRegistry.register(savestateHandlerServer);
 		PacketHandlerRegistry.register(savestateHandlerServer.getPlayerHandler());
+		EventListenerRegistry.register(savestateHandlerServer.getSavestateTemporaryHandler());
 
 		if (!server.isDedicatedServer()) {
 			TASmod.tickratechanger.ticksPerSecond = 0F;
@@ -187,6 +188,8 @@ public class TASmod implements ModInitializer, EventServerInit, EventServerStop 
 		if (savestateHandlerServer != null) {
 			PacketHandlerRegistry.unregister(savestateHandlerServer); // Unregistering the savestatehandler, as a new instance is registered in onServerStart()
 			PacketHandlerRegistry.unregister(savestateHandlerServer.getPlayerHandler());
+			PacketHandlerRegistry.unregister(savestateHandlerServer);
+			EventListenerRegistry.unregister(savestateHandlerServer.getSavestateTemporaryHandler());
 
 			savestateHandlerServer = null;
 		}

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandFullPlay.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandFullPlay.java
@@ -1,19 +1,11 @@
 package com.minecrafttas.tasmod.commands;
 
 import com.minecrafttas.tasmod.TASmod;
-import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
-import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
-import com.minecrafttas.tasmod.registries.TASmodPackets;
-import com.minecrafttas.tasmod.savestates.SavestateHandlerServer.SavestateCallback;
-import com.minecrafttas.tasmod.savestates.SavestateHandlerServer.SavestateFlags;
-import com.minecrafttas.tasmod.savestates.exceptions.LoadstateException;
 
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.text.TextComponentString;
-import net.minecraft.util.text.TextFormatting;
 
 public class CommandFullPlay extends CommandBase {
 
@@ -29,33 +21,6 @@ public class CommandFullPlay extends CommandBase {
 
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-
-		SavestateCallback cb = (paths) -> {
-			try {
-				TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.SAVESTATE_CLEAR_SCREEN));
-			} catch (Exception e) {
-				TASmod.LOGGER.catching(e);
-			}
-		};
-
-		try {
-			TASmod.savestateHandlerServer.loadState(0, cb, SavestateFlags.BLOCK_CHANGE_INDEX, SavestateFlags.BLOCK_PAUSE_TICKRATE);
-		} catch (LoadstateException e) {
-			sender.sendMessage(new TextComponentString(TextFormatting.RED + "Failed to load a savestate: " + e.getMessage()));
-			return;
-		} catch (Exception e) {
-			sender.sendMessage(new TextComponentString(TextFormatting.RED + "Failed to load a savestate: " + e.getCause().toString()));
-			e.printStackTrace();
-			return;
-		} finally {
-			TASmod.savestateHandlerServer.resetState();
-		}
-		TASmod.playbackControllerServer.setServerState(TASstate.PLAYBACK);
-		try {
-			TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.PLAYBACK_FULLPLAY));
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+		TASmod.playbackControllerServer.fullPlay();
 	}
-
 }

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandFullRecord.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandFullRecord.java
@@ -1,19 +1,11 @@
 package com.minecrafttas.tasmod.commands;
 
 import com.minecrafttas.tasmod.TASmod;
-import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
-import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
-import com.minecrafttas.tasmod.registries.TASmodPackets;
-import com.minecrafttas.tasmod.savestates.SavestateHandlerServer.SavestateCallback;
-import com.minecrafttas.tasmod.savestates.SavestateHandlerServer.SavestateFlags;
-import com.minecrafttas.tasmod.savestates.exceptions.SavestateException;
 
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.text.TextComponentString;
-import net.minecraft.util.text.TextFormatting;
 
 public class CommandFullRecord extends CommandBase {
 
@@ -29,28 +21,6 @@ public class CommandFullRecord extends CommandBase {
 
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-
-		SavestateCallback cb = (paths) -> {
-			try {
-				TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.SAVESTATE_CLEAR_SCREEN));
-			} catch (Exception e) {
-				TASmod.LOGGER.catching(e);
-			}
-		};
-
-		try {
-			TASmod.savestateHandlerServer.saveState(0, cb, SavestateFlags.BLOCK_PAUSE_TICKRATE);
-		} catch (SavestateException e) {
-			sender.sendMessage(new TextComponentString(TextFormatting.RED + "Failed to create a savestate: " + e.getMessage()));
-			return;
-		} finally {
-			TASmod.savestateHandlerServer.resetState();
-		}
-		TASmod.playbackControllerServer.setServerState(TASstate.RECORDING);
-		try {
-			TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.PLAYBACK_FULLRECORD));
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+		TASmod.playbackControllerServer.fullRecord();
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandPlay.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandPlay.java
@@ -42,11 +42,10 @@ public class CommandPlay extends CommandBase {
 			return;
 		}
 		if (args.length <= 1) {
-			boolean loadTempSavestate = true;
-			if (args.length == 1 && "nosave".equals(args[0])) {
-				loadTempSavestate = false;
-			}
-			TASmod.playbackControllerServer.togglePlayback(loadTempSavestate);
+			boolean noSave = args.length == 1 && "nosave".equals(args[0]);
+			TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setNoSave(noSave);
+
+			TASmod.playbackControllerServer.togglePlayback();
 		} else if (args.length > 2) {
 			sender.sendMessage(new TextComponentString(TextFormatting.RED + "Too many arguments. " + getUsage(sender)));
 		}

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandRecord.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandRecord.java
@@ -42,11 +42,9 @@ public class CommandRecord extends CommandBase {
 			return;
 		}
 		if (args.length <= 1) {
-			boolean saveTempSavestate = true;
-			if (args.length == 1 && "nosave".equals(args[0])) {
-				saveTempSavestate = false;
-			}
-			TASmod.playbackControllerServer.toggleRecording(saveTempSavestate);
+			boolean noSave = args.length == 1 && "nosave".equals(args[0]);
+			TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setNoSave(noSave);
+			TASmod.playbackControllerServer.toggleRecording();
 		} else if (args.length > 1) {
 			sender.sendMessage(new TextComponentString(TextFormatting.RED + "Too many arguments. " + getUsage(sender)));
 		}

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandRestartAndPlay.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandRestartAndPlay.java
@@ -6,11 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.minecrafttas.tasmod.TASmod;
-import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
-import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
-import com.minecrafttas.tasmod.registries.TASmodPackets;
-import com.minecrafttas.tasmod.savestates.SavestateHandlerServer.SavestateFlags;
-import com.minecrafttas.tasmod.savestates.exceptions.LoadstateException;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandBase;
@@ -39,31 +34,7 @@ public class CommandRestartAndPlay extends CommandBase {
 			if (args.length < 1) {
 				sender.sendMessage(new TextComponentString(TextFormatting.RED + "Please add a filename, " + getUsage(sender)));
 			} else {
-				String name = "";
-				String spacer = " ";
-				for (int i = 0; i < args.length; i++) {
-					if (i == args.length - 1) {
-						spacer = "";
-					}
-					name = name.concat(args[i] + spacer);
-				}
-				try {
-					TASmod.savestateHandlerServer.loadState(0, null, SavestateFlags.BLOCK_PAUSE_TICKRATE);
-				} catch (LoadstateException e) {
-					TASmod.LOGGER.catching(e);
-					if (e.getMessage() != null) {
-						sender.sendMessage(new TextComponentString(TextFormatting.RED + "Could not load the initial savestate: " + e.getMessage()));
-					}
-					TASmod.savestateHandlerServer.resetState();
-					TASmod.tickratechanger.pauseGame(false);
-					return;
-				}
-				TASmod.playbackControllerServer.setServerState(TASstate.PLAYBACK);
-				try {
-					TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.PLAYBACK_RESTARTANDPLAY).writeString(args[0]));
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
+				TASmod.playbackControllerServer.restartAndPlay(String.join(" ", args));
 			}
 		} else {
 			sender.sendMessage(new TextComponentString(TextFormatting.RED + "You have no permission to use this command"));

--- a/src/main/java/com/minecrafttas/tasmod/events/EventPlaybackServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/EventPlaybackServer.java
@@ -8,9 +8,8 @@ public interface EventPlaybackServer {
 
 	/**
 	 * Fired when {@link PlaybackControllerServer#setTASStateServer(TASstate)} is called
-	 * 
-	 * @author Scribble
 	 */
+	@FunctionalInterface
 	public interface EventControllerStateChange extends EventBase {
 		/**
 		 * Fired when {@link PlaybackControllerServer#setTASStateServer(TASstate)} is called
@@ -21,13 +20,13 @@ public interface EventPlaybackServer {
 	}
 
 	/**
-	 * Fired when a recording is cleared
+	 * Fired when a recording is cleared in {@link PlaybackControllerServer#clearInputs()}
 	 */
 	@FunctionalInterface
 	public interface EventRecordClear extends EventBase {
 
 		/**
-		 * Fired when a recording is cleared
+		 * Fired when a recording is cleared in {@link PlaybackControllerServer#clearInputs()}
 		 */
 		public void onRecordingClear();
 	}

--- a/src/main/java/com/minecrafttas/tasmod/events/EventPlaybackServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/events/EventPlaybackServer.java
@@ -1,0 +1,34 @@
+package com.minecrafttas.tasmod.events;
+
+import com.minecrafttas.mctcommon.events.EventListenerRegistry.EventBase;
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
+import com.minecrafttas.tasmod.playback.PlaybackControllerServer;
+
+public interface EventPlaybackServer {
+
+	/**
+	 * Fired when {@link PlaybackControllerServer#setTASStateServer(TASstate)} is called
+	 * 
+	 * @author Scribble
+	 */
+	public interface EventControllerStateChange extends EventBase {
+		/**
+		 * Fired when {@link PlaybackControllerServer#setTASStateServer(TASstate)} is called
+		 * @param newstate The new state that the playback controller is about to be set
+		 * @param oldstate The current state that is about to be replaced by newstate
+		 */
+		public void onControllerStateChange(TASstate newstate, TASstate oldstate);
+	}
+
+	/**
+	 * Fired when a recording is cleared
+	 */
+	@FunctionalInterface
+	public interface EventRecordClear extends EventBase {
+
+		/**
+		 * Fired when a recording is cleared
+		 */
+		public void onRecordingClear();
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -1015,7 +1015,7 @@ public class PlaybackControllerClient implements
 				break;
 
 			case PLAYBACK_RESTARTANDPLAY:
-				String finalname = ByteBufferBuilder.readString(buf);
+				String tasFilename = ByteBufferBuilder.readString(buf);
 
 				try {
 					Thread.sleep(100L);
@@ -1023,7 +1023,7 @@ public class PlaybackControllerClient implements
 					e.printStackTrace();
 				}
 				Minecraft.getMinecraft().addScheduledTask(() -> {
-					TASmodClient.config.set(TASmodConfig.FileToOpen, finalname);
+					TASmodClient.config.set(TASmodConfig.FileToOpen, tasFilename);
 					System.exit(0);
 				});
 				break;

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -9,6 +9,7 @@ import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_RESTARTA
 import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_SAVE;
 import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_STATE;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
@@ -1014,7 +1015,7 @@ public class PlaybackControllerClient implements
 				break;
 
 			case PLAYBACK_RESTARTANDPLAY:
-				final String finalname = ByteBufferBuilder.readString(buf);
+				String finalname = ByteBufferBuilder.readString(buf);
 
 				try {
 					Thread.sleep(100L);
@@ -1077,5 +1078,13 @@ public class PlaybackControllerClient implements
 		} else {
 			TASmodClient.config.reset(TASmodConfig.FileToOpen);
 		}
+
+		try {
+			TASmodClient.controller.setInputs(PlaybackSerialiser.loadFromFile(tasFileDirectory.resolve(fileOnStart + fileEnding)));
+		} catch (PlaybackLoadException | IOException e) {
+			logger.catching(e);
+		}
+
+		setTASState(TASstate.PLAYBACK);
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerServer.java
@@ -1,6 +1,10 @@
 package com.minecrafttas.tasmod.playback;
 
 import static com.minecrafttas.tasmod.TASmod.LOGGER;
+import static com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate.NONE;
+import static com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate.PAUSED;
+import static com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate.PLAYBACK;
+import static com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate.RECORDING;
 import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_CLEAR_INPUTS;
 import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_FULLPLAY;
 import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_FULLRECORD;
@@ -8,19 +12,26 @@ import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_LOAD;
 import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_RESTARTANDPLAY;
 import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_SAVE;
 import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_STATE;
+import static com.minecrafttas.tasmod.registries.TASmodPackets.SAVESTATE_CLEAR_SCREEN;
 import static com.minecrafttas.tasmod.util.LoggerMarkers.Playback;
 
 import java.nio.ByteBuffer;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import com.minecrafttas.mctcommon.networking.Client.Side;
 import com.minecrafttas.mctcommon.networking.exception.PacketNotImplementedException;
 import com.minecrafttas.mctcommon.networking.exception.WrongSideException;
 import com.minecrafttas.mctcommon.networking.interfaces.PacketID;
 import com.minecrafttas.mctcommon.networking.interfaces.ServerPacketHandler;
 import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.events.EventPlaybackServer;
 import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
 import com.minecrafttas.tasmod.registries.TASmodPackets;
+import com.minecrafttas.tasmod.savestates.SavestateHandlerServer.SavestateCallback;
+import com.minecrafttas.tasmod.savestates.SavestateHandlerServer.SavestateFlags;
+import com.minecrafttas.tasmod.savestates.exceptions.LoadstateException;
+import com.minecrafttas.tasmod.savestates.exceptions.SavestateException;
 
 /**
  * The playback controller on the server side.<br>
@@ -32,8 +43,6 @@ import com.minecrafttas.tasmod.registries.TASmodPackets;
 public class PlaybackControllerServer implements ServerPacketHandler {
 
 	private TASstate state;
-
-	private boolean createState = true;
 
 	@Override
 	public PacketID[] getAcceptedPacketIDs() {
@@ -60,15 +69,22 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 			case PLAYBACK_STATE:
 				TASstate networkState = TASmodBufferBuilder.readEnum(TASstate.class, buf);
 				/* TODO Permissions */
-				setState(networkState);
+				setTASState(networkState);
 				break;
 
 			case PLAYBACK_CLEAR_INPUTS:
 				clearInputs();
 				break;
-			case PLAYBACK_FULLPLAY:
 			case PLAYBACK_FULLRECORD:
+				fullRecord();
+				break;
+			case PLAYBACK_FULLPLAY:
+				fullPlay();
+				break;
 			case PLAYBACK_RESTARTANDPLAY:
+				String tasFileName = TASmodBufferBuilder.readString(buf);
+				restartAndPlay(tasFileName);
+				break;
 			case PLAYBACK_SAVE:
 			case PLAYBACK_LOAD:
 				TASmod.server.sendToAll(new TASmodBufferBuilder(buf));
@@ -79,56 +95,39 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 		}
 	}
 
-	public void setState(TASstate stateIn) {
-		setServerState(stateIn);
+	public void setTASState(TASstate stateIn) {
+		setTASStateServer(stateIn);
 		try {
-			TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.PLAYBACK_STATE).writeEnum(state).writeBoolean(true));
+			TASmod.server.sendToAll(new TASmodBufferBuilder(PLAYBACK_STATE).writeEnum(state).writeBoolean(true));
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
 	}
 
-	public void setServerState(TASstate stateIn) {
+	public void setTASStateServer(TASstate stateIn) {
 		if (state != stateIn) {
-			if (state == TASstate.RECORDING && stateIn == TASstate.PLAYBACK)
+			if (state == RECORDING && stateIn == PLAYBACK)
 				return;
-			if (state == TASstate.NONE && state == TASstate.PAUSED) {
+			if (state == NONE && state == PAUSED) {
 				return;
 			}
+			EventListenerRegistry.fireEvent(EventPlaybackServer.EventControllerStateChange.class, stateIn, this.state);
+
 			this.state = stateIn;
 			LOGGER.info(Playback, "Set the server state to {}", stateIn.toString());
 		}
 	}
 
-	public void toggleRecording(boolean saveSavestate) {
-		if (state == TASstate.NONE && createState && saveSavestate) {
-			createState = false;
-			TASmod.savestateHandlerServer.saveStateTemp((paths) -> {
-				try {
-					TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.SAVESTATE_CLEAR_SCREEN));
-				} catch (Exception e) {
-					TASmod.LOGGER.catching(e);
-				}
-			});
-		}
-		setState(state == TASstate.RECORDING ? TASstate.NONE : TASstate.RECORDING);
+	public void toggleRecording() {
+		setTASState(state == RECORDING ? NONE : RECORDING);
 	}
 
-	public void togglePlayback(boolean loadSavestate) {
-		if (state == TASstate.NONE && loadSavestate) {
-			TASmod.savestateHandlerServer.loadStateTemp((paths) -> {
-				try {
-					TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.SAVESTATE_CLEAR_SCREEN));
-				} catch (Exception e) {
-					TASmod.LOGGER.catching(e);
-				}
-			});
-		}
-		setState(state == TASstate.PLAYBACK ? TASstate.NONE : TASstate.PLAYBACK);
+	public void togglePlayback() {
+		setTASState(state == PLAYBACK ? NONE : PLAYBACK);
 	}
 
 	public void clearInputs() {
-		createState = true;
+		EventListenerRegistry.fireEvent(EventPlaybackServer.EventRecordClear.class);
 		try {
 			TASmod.server.sendToAll(new TASmodBufferBuilder(PLAYBACK_CLEAR_INPUTS));
 		} catch (Exception e) {
@@ -140,4 +139,82 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 		return state;
 	}
 
+	public void fullRecord() {
+		SavestateCallback cb = (paths) -> {
+			try {
+				TASmod.server.sendToAll(new TASmodBufferBuilder(SAVESTATE_CLEAR_SCREEN));
+			} catch (Exception e) {
+				LOGGER.catching(e);
+			}
+		};
+
+		TASmod.tickSchedulerServer.add(() -> {
+			try {
+				TASmod.savestateHandlerServer.saveState(0, cb, SavestateFlags.BLOCK_PAUSE_TICKRATE);
+			} catch (SavestateException e) {
+				LOGGER.catching(e);
+				return;
+			} finally {
+				TASmod.savestateHandlerServer.resetState();
+			}
+
+			setTASStateServer(TASstate.RECORDING);
+
+			try {
+				TASmod.server.sendToAll(new TASmodBufferBuilder(PLAYBACK_FULLRECORD));
+			} catch (Exception e) {
+				LOGGER.catching(e);
+			}
+		});
+	}
+
+	public void fullPlay() {
+		SavestateCallback cb = (paths) -> {
+			try {
+				TASmod.server.sendToAll(new TASmodBufferBuilder(TASmodPackets.SAVESTATE_CLEAR_SCREEN));
+			} catch (Exception e) {
+				LOGGER.catching(e);
+			}
+		};
+
+		TASmod.tickSchedulerServer.add(() -> {
+			try {
+				TASmod.savestateHandlerServer.loadState(0, cb, SavestateFlags.BLOCK_CHANGE_INDEX, SavestateFlags.BLOCK_PAUSE_TICKRATE);
+			} catch (LoadstateException e) {
+				LOGGER.catching(e);
+				return;
+			} finally {
+				TASmod.savestateHandlerServer.resetState();
+			}
+
+			setTASStateServer(TASstate.PLAYBACK);
+
+			try {
+				TASmod.server.sendToAll(new TASmodBufferBuilder(PLAYBACK_FULLPLAY));
+			} catch (Exception e) {
+				LOGGER.catching(e);
+			}
+		});
+	}
+
+	public void restartAndPlay(String tasFileName) {
+		TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setNoSave(true);
+		TASmod.playbackControllerServer.setTASStateServer(PLAYBACK);
+
+		TASmod.tickSchedulerServer.add(() -> {
+			try {
+				TASmod.savestateHandlerServer.loadState(0, null, SavestateFlags.BLOCK_PAUSE_TICKRATE);
+			} catch (LoadstateException e) {
+				LOGGER.catching(e);
+				TASmod.savestateHandlerServer.resetState();
+				TASmod.tickratechanger.pauseGame(false);
+				return;
+			}
+			try {
+				TASmod.server.sendToAll(new TASmodBufferBuilder(PLAYBACK_RESTARTANDPLAY).writeString(tasFileName));
+			} catch (Exception e) {
+				LOGGER.catching(e);
+			}
+		});
+	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/registries/TASmodPackets.java
+++ b/src/main/java/com/minecrafttas/tasmod/registries/TASmodPackets.java
@@ -180,7 +180,7 @@ public enum TASmodPackets implements PacketID {
 	 * <p>Notifies the client to quit the game. Upon restarting the game, the specified tasfile will be loaded and played back in {@link PlaybackControllerClient}
 	 * <p>SIDE: Both<br>
 	 * ARGS: <br>
-	 * <strong>Client->Server</strong> None<br>
+	 * <strong>Client->Server</strong> String filename The TASfile name to load on restart<br>
 	 * <strong>Server->Client</strong> String filename The TASfile name to load on restart
 	 */
 	PLAYBACK_RESTARTANDPLAY,

--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
@@ -35,6 +35,7 @@ import com.minecrafttas.tasmod.savestates.exceptions.SavestateDeleteException;
 import com.minecrafttas.tasmod.savestates.exceptions.SavestateException;
 import com.minecrafttas.tasmod.savestates.handlers.SavestatePlayerHandlerServer;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateResourcePackHandler;
+import com.minecrafttas.tasmod.savestates.handlers.SavestateTempHandler;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateWorldHandler;
 import com.minecrafttas.tasmod.util.Component;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
@@ -72,6 +73,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 
 	private final SavestatePlayerHandlerServer playerHandler;
 	private final SavestateWorldHandler worldHandler;
+	private final SavestateTempHandler tempSavestateHandler;
 
 	private final Logger logger;
 
@@ -87,6 +89,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 
 		this.playerHandler = new SavestatePlayerHandlerServer(server);
 		this.worldHandler = new SavestateWorldHandler(server);
+		this.tempSavestateHandler = new SavestateTempHandler(this, logger);
 
 		createIndexer(server);
 	}
@@ -408,10 +411,6 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		indexer.deleteMultipleSavestates(from, to, onDelete, err);
 	}
 
-	public SavestatePlayerHandlerServer getPlayerHandler() {
-		return playerHandler;
-	}
-
 	public int getCurrentIndex() {
 		return indexer.getCurrentSavestate().index;
 	}
@@ -666,5 +665,13 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 
 	public void reload() {
 		indexer.reload();
+	}
+
+	public SavestatePlayerHandlerServer getPlayerHandler() {
+		return playerHandler;
+	}
+
+	public SavestateTempHandler getSavestateTemporaryHandler() {
+		return tempSavestateHandler;
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateTempHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateTempHandler.java
@@ -1,0 +1,79 @@
+package com.minecrafttas.tasmod.savestates.handlers;
+
+import static com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate.NONE;
+import static com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate.PLAYBACK;
+import static com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate.RECORDING;
+import static com.minecrafttas.tasmod.registries.TASmodPackets.SAVESTATE_CLEAR_SCREEN;
+
+import org.apache.logging.log4j.Logger;
+
+import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.events.EventPlaybackClient.EventRecordClear;
+import com.minecrafttas.tasmod.events.EventPlaybackServer.EventControllerStateChange;
+import com.minecrafttas.tasmod.networking.TASmodBufferBuilder;
+import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
+import com.minecrafttas.tasmod.savestates.SavestateHandlerServer;
+
+/**
+ * <p>Handles the creation of temporary savestates when recording/playing back a TAS
+ * <p>Is exclusively run on the server side
+ * 
+ * @author Scribble
+ */
+public class SavestateTempHandler implements EventControllerStateChange, EventRecordClear {
+
+	private final Logger logger;
+	private final SavestateHandlerServer handler;
+
+	private boolean createState = true;
+	private boolean noSave = false;
+
+	public SavestateTempHandler(SavestateHandlerServer handler, Logger logger) {
+		this.logger = logger;
+		this.handler = handler;
+	}
+
+	@Override
+	public void onControllerStateChange(TASstate newstate, TASstate oldstate) {
+
+		if (oldstate != NONE) {
+			return;
+		}
+
+		if (noSave) {
+			noSave = false;
+			return;
+		}
+
+		if (newstate == RECORDING && createState) {
+			logger.info("Creating temporary savestate");
+			createState = false;
+			handler.saveStateTemp((paths) -> {
+				try {
+					TASmod.server.sendToAll(new TASmodBufferBuilder(SAVESTATE_CLEAR_SCREEN));
+				} catch (Exception e) {
+					logger.catching(e);
+				}
+			});
+		} else if (newstate == PLAYBACK) {
+			logger.info("Loading temporary savestate");
+			createState = false;
+			handler.loadStateTemp((paths) -> {
+				try {
+					TASmod.server.sendToAll(new TASmodBufferBuilder(SAVESTATE_CLEAR_SCREEN));
+				} catch (Exception e) {
+					logger.catching(e);
+				}
+			});
+		}
+	}
+
+	@Override
+	public void onRecordingClear() {
+		createState = true;
+	}
+
+	public void setNoSave(boolean noSave) {
+		this.noSave = noSave;
+	}
+}


### PR DESCRIPTION
I was just optimizing temporary savestates to not occupy space in the PlaybackControllerServer, when I noticed that `/restartandplay` just doesn't work and it hasn't since [January 2024](https://github.com/MinecraftTAS/TASmod/commit/75406a80cd8202258e4bf1e7bff2afd858fed7c5#diff-fd817eb25a9bf3ac38244a1affb78bc46b756c7d10fef1f6dadec412bb7eaac1R129) when I was reworking the VirtualInput engine.

I never noticed that I forgot to reimplement it... I even took care of the TODO and still didn't see that it didn't work

## Changes
- Update PlaybackControllerServer to work with packets and not only with commands
- [Savestates] Seperate temporary savestates into it's own handler