### PR TITLE
Update legacy-fabric and switch mappings to ornithe-mcp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,10 @@
 plugins {
 	// loom plugin
-    id "fabric-loom" version "${loom_version}"
-    // legacy looming (loom plugin improvements)
-    id "legacy-looming" version "${loom_version}"
-    id "com.palantir.git-version" version "4.2.0"
-    id "com.diffplug.spotless" version "8.1.0"
+	id "fabric-loom" version "${loom_version}"
+	id "ploceus" version "${loom_version}"
+	id "com.palantir.git-version" version "4.2.0"
+	id "com.diffplug.spotless" version "8.1.0"
 }
-
 
 // set basic properties
 def hash = ""
@@ -34,34 +32,38 @@ loom {
 
 // dependency repositories
 repositories {
-    mavenCentral()
-    maven { url = "https://maven.minecrafttas.com/main" }
-    //maven { url = "https://maven.minecrafttas.com/snapshots" }
-    maven { url = "https://raw.githubusercontent.com/BleachDev/cursed-mappings/main/" }
-    maven { url = "https://jitpack.io" }
-    maven { url = "https://repo.spongepowered.org/maven" }
+	mavenCentral()
+	maven { url = "https://maven.minecrafttas.com/main" }
+	maven { url = "https://maven.legacyfabric.net/" }
+	//maven { url = "https://maven.minecrafttas.com/snapshots" }
+	maven { url = "https://jitpack.io" }
+	maven { url = "https://repo.spongepowered.org/maven" }
 }
 
 // dependency configurations
 configurations {
-    // embed dependency included in build
-    implementation.extendsFrom(embed)
+	// embed dependency included in build
+	implementation.extendsFrom(embed)
+}
+
+ploceus {
+	setIntermediaryGeneration(2)
 }
 
 // dependencies
 dependencies {
-    // tasmod dependencies
-    embed "com.dselent:bigarraylist:1.6"
-    embed "com.github.KaptainWutax:SeedUtils:b6a383113c"
+	// tasmod dependencies
+	embed "com.dselent:bigarraylist:1.6"
+	embed "com.github.KaptainWutax:SeedUtils:b6a383113c"
 
 	// loom dependencies
-    minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.legacyfabric:yarn:${project.minecraft_version}+build.mcp"
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	mappings ploceus.mcpMappings(project.mcp_channel, project.mcp_mcversion, project.mcp_build)
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	
+
 	// testing dependencies
-    testImplementation "org.junit.jupiter:junit-jupiter:5.14.1"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+	testImplementation "org.junit.jupiter:junit-jupiter:5.14.1"
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
 
@@ -71,12 +73,12 @@ compileJava {
 
 // process fabric mod json
 processResources {
-    inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft_version
-    
-    filesMatching("fabric.mod.json") {
-        expand "mod_url": project.mod_url, "name": project.mod_name, "mod_version": project.version, "mod_description": project.mod_description, "mod_sources": project.mod_sources, "mod_email": project.mod_email
-    }
+	inputs.property "version", project.version
+	inputs.property "mcversion", project.minecraft_version
+
+	filesMatching("fabric.mod.json") {
+		expand "mod_url": project.mod_url, "name": project.mod_name, "mod_version": project.version, "mod_description": project.mod_description, "mod_sources": project.mod_sources, "mod_email": project.mod_email
+	}
 }
 
 // configure jar file
@@ -85,14 +87,14 @@ jar {
 	// pack embedded stuff
 	from {
 		configurations.embed.collect { it.isDirectory() ? it : zipTree(it) }
-    } {
-        exclude "LICENSE.txt", "META-INF/MANIFSET.MF", "META-INF/maven/**", "META-INF/*.RSA", "META-INF/*.SF"
+	} {
+		exclude "LICENSE.txt", "META-INF/MANIFSET.MF", "META-INF/maven/**", "META-INF/*.RSA", "META-INF/*.SF"
     }
 }
 
 // configure testing
 tasks.named("test", Test) {
-    useJUnitPlatform()
+	useJUnitPlatform()
 
 	testLogging {
 		events "passed", "skipped", "failed"
@@ -103,8 +105,8 @@ spotless {
 	encoding "UTF-8"
 	lineEndings "UNIX"
 	java {
-	importOrderFile("formatter/TASmodImportorder.txt")
-	eclipse().configFile("formatter/TASmodFormatter.xml")
+		importOrderFile("formatter/TASmodImportorder.txt")
+		eclipse().configFile("formatter/TASmodFormatter.xml")
 	}
 	enforceCheck false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,10 @@ org.gradle.jvmargs=-Xmx3G
 # Fabric properties
 minecraft_version=1.12.2
 loader_version=0.18.4
-loom_version=1.14-SNAPSHOT
+loom_version=1.15-SNAPSHOT
+mcp_channel=stable
+mcp_build=39
+mcp_mcversion=1.12
 
 # Mod properties
 mod_name=Tool-Assisted Speedrun Mod

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,8 @@ pluginManagement {
     repositories {
 		maven { url = "https://maven.minecrafttas.com/main" }
         maven { url = "https://maven.fabricmc.net/" }
-        maven { url = "https://repo.legacyfabric.net/repository/legacyfabric/" }
+        maven { url = "https://maven.ornithemc.net/releases" }
+        maven { url = "https://maven.ornithemc.net/snapshots" }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/src/main/java/com/minecrafttas/mctcommon/mixin/MixinNetHandlerPlayClient.java
+++ b/src/main/java/com/minecrafttas/mctcommon/mixin/MixinNetHandlerPlayClient.java
@@ -20,11 +20,11 @@ import net.minecraft.network.play.server.SPacketPlayerListItem.Action;
 @Mixin(NetHandlerPlayClient.class)
 public class MixinNetHandlerPlayClient {
 	@Shadow
-	private Minecraft gameController;
+	private Minecraft client;
 
 	@Inject(method = "handleJoinGame", at = @At(value = "RETURN"))
 	public void clientJoinServerEvent(CallbackInfo ci) throws ConnectException {
-		EventListenerRegistry.fireEvent(EventPlayerJoinedClientSide.class, gameController.player);
+		EventListenerRegistry.fireEvent(EventPlayerJoinedClientSide.class, client.player);
 	}
 
 	@Inject(method = "handlePlayerListItem", at = @At(value = "HEAD"))

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -66,9 +66,9 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 
 	public static TickSyncClient ticksyncClient;
 
-	public final static Path tasfiledirectory = Minecraft.getMinecraft().mcDataDir.toPath().resolve("saves").resolve("tasfiles");
+	public final static Path tasfiledirectory = Minecraft.getMinecraft().gameDir.toPath().resolve("saves").resolve("tasfiles");
 
-	public final static Path savestatedirectory = Minecraft.getMinecraft().mcDataDir.toPath().resolve("saves").resolve("savestates");
+	public final static Path savestatedirectory = Minecraft.getMinecraft().gameDir.toPath().resolve("saves").resolve("savestates");
 
 	public static InfoHud hud;
 
@@ -353,7 +353,7 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 	}
 
 	private void loadConfig(Minecraft mc) {
-		Path configDir = mc.mcDataDir.toPath().resolve("config");
+		Path configDir = mc.gameDir.toPath().resolve("config");
 		if (!Files.exists(configDir)) {
 			try {
 				Files.createDirectory(configDir);

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandRestartAndPlay.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandRestartAndPlay.java
@@ -57,7 +57,7 @@ public class CommandRestartAndPlay extends CommandBase {
 
 	public List<String> getFilenames() {
 		List<String> tab = new ArrayList<String>();
-		File folder = new File(Minecraft.getMinecraft().mcDataDir, "saves" + File.separator + "tasfiles");
+		File folder = new File(Minecraft.getMinecraft().gameDir, "saves" + File.separator + "tasfiles");
 		File[] listOfFiles = folder.listFiles(new FileFilter() {
 			@Override
 			public boolean accept(File pathname) {

--- a/src/main/java/com/minecrafttas/tasmod/gui/InfoHud.java
+++ b/src/main/java/com/minecrafttas/tasmod/gui/InfoHud.java
@@ -23,7 +23,6 @@ import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
 import com.minecrafttas.tasmod.playback.filecommands.builtin.DesyncMonitorFileCommandExtension;
 import com.minecrafttas.tasmod.virtual.VirtualInput;
 import com.minecrafttas.tasmod.virtual.VirtualInterpolationHandler.MouseInterpolation;
-import com.mojang.realmsclient.gui.ChatFormatting;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
@@ -199,7 +198,7 @@ public class InfoHud extends GuiScreen implements EventClientTick, EventDrawHotb
 			return;
 		}
 		try {
-			File tasmodDir = new File(Minecraft.getMinecraft().mcDataDir, "tasmod");
+			File tasmodDir = new File(Minecraft.getMinecraft().gameDir, "tasmod");
 			tasmodDir.mkdir();
 			File configFile = new File(tasmodDir, "infogui2.cfg");
 			if (!configFile.exists())
@@ -228,7 +227,7 @@ public class InfoHud extends GuiScreen implements EventClientTick, EventDrawHotb
 		try {
 			configuration = new Properties();
 			if (!resetLayout) {
-				File tasmodDir = new File(Minecraft.getMinecraft().mcDataDir, "tasmod");
+				File tasmodDir = new File(Minecraft.getMinecraft().gameDir, "tasmod");
 				tasmodDir.mkdir();
 				File configFile = new File(tasmodDir, "infogui2.cfg");
 				if (!configFile.exists())
@@ -368,17 +367,17 @@ public class InfoHud extends GuiScreen implements EventClientTick, EventDrawHotb
 							return "State";
 						} else {
 							TASstate state = TASmodClient.controller.getState();
-							ChatFormatting format = ChatFormatting.WHITE;
+							TextFormatting format = TextFormatting.WHITE;
 							String out = "";
 							if (state == TASstate.PLAYBACK) {
 								out = "Playback";
-								format = ChatFormatting.GREEN;
+								format = TextFormatting.GREEN;
 							} else if (state == TASstate.RECORDING) {
 								out = "Recording";
-								format = ChatFormatting.RED;
+								format = TextFormatting.RED;
 							} else if (state == TASstate.PAUSED) {
 								out = "Paused";
-								format = ChatFormatting.YELLOW;
+								format = TextFormatting.YELLOW;
 							} else if (state == TASstate.NONE) {
 								out = "";
 							}

--- a/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraftServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/MixinMinecraftServer.java
@@ -3,6 +3,7 @@ package com.minecrafttas.tasmod.mixin;
 import java.util.Queue;
 import java.util.concurrent.FutureTask;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -52,9 +53,11 @@ public abstract class MixinMinecraftServer {
 	@Shadow
 	private long currentTime;
 
+	@Final
 	@Shadow
 	private Queue<FutureTask<?>> futureTaskQueue;
 
+	@Final
 	@Shadow
 	private NetworkSystem networkSystem;
 

--- a/src/main/java/com/minecrafttas/tasmod/mixin/playbackhooks/MixinEntityRenderer.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/playbackhooks/MixinEntityRenderer.java
@@ -1,5 +1,6 @@
 package com.minecrafttas.tasmod.mixin.playbackhooks;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -37,6 +38,7 @@ import net.minecraft.client.renderer.GlStateManager;
 @Mixin(EntityRenderer.class)
 public class MixinEntityRenderer implements SubtickDuck {
 
+	@Final
 	@Shadow
 	private Minecraft mc;
 	@Shadow

--- a/src/main/java/com/minecrafttas/tasmod/mixin/savestates/MixinChunkProviderClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/savestates/MixinChunkProviderClient.java
@@ -20,7 +20,7 @@ import net.minecraft.world.chunk.Chunk;
 public class MixinChunkProviderClient implements ChunkProviderDuck {
 	@Shadow
 	@Final
-	private Long2ObjectMap<Chunk> chunkMapping;
+	private Long2ObjectMap<Chunk> loadedChunks;
 
 	/**
 	 * <p>Unloads chunk data on the client.
@@ -28,13 +28,13 @@ public class MixinChunkProviderClient implements ChunkProviderDuck {
 	 */
 	@Override
 	public void unloadAllChunks() {
-		ObjectIterator<?> objectiterator = this.chunkMapping.values().iterator();
+		ObjectIterator<?> objectiterator = this.loadedChunks.values().iterator();
 
 		while (objectiterator.hasNext()) {
 			Chunk chunk = (Chunk) objectiterator.next();
 			chunk.onUnload();
 		}
-		chunkMapping.clear();
+		loadedChunks.clear();
 	}
 
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/savestates/MixinChunkProviderServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/savestates/MixinChunkProviderServer.java
@@ -24,7 +24,7 @@ public abstract class MixinChunkProviderServer implements ChunkProviderDuck {
 	 */
 	@Shadow
 	@Final
-	private Long2ObjectMap<Chunk> id2ChunkMap;
+	private Long2ObjectMap<Chunk> loadedChunks;
 
 	/**
 	 * <p>Saves and unloads chunk data.
@@ -34,7 +34,7 @@ public abstract class MixinChunkProviderServer implements ChunkProviderDuck {
 	 */
 	@Override
 	public void unloadAllChunks() {
-		ObjectIterator<?> objectiterator = this.id2ChunkMap.values().iterator();
+		ObjectIterator<?> objectiterator = this.loadedChunks.values().iterator();
 
 		while (objectiterator.hasNext()) {
 			Chunk chunk = (Chunk) objectiterator.next();
@@ -42,7 +42,7 @@ public abstract class MixinChunkProviderServer implements ChunkProviderDuck {
 			this.saveChunkExtraData(chunk);
 			chunk.onUnload();
 		}
-		id2ChunkMap.clear();
+		loadedChunks.clear();
 	}
 
 	@Shadow

--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerClient.java
@@ -28,7 +28,6 @@ import com.minecrafttas.tasmod.savestates.exceptions.SavestateException;
 import com.minecrafttas.tasmod.util.Ducks.ChunkProviderDuck;
 import com.minecrafttas.tasmod.util.Ducks.WorldClientDuck;
 import com.minecrafttas.tasmod.util.LoggerMarkers;
-import com.mojang.realmsclient.gui.ChatFormatting;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -37,6 +36,7 @@ import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.multiplayer.ChunkProviderClient;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.chunk.Chunk;
 
 /**
@@ -93,7 +93,7 @@ public class SavestateHandlerClient implements ClientPacketHandler, EventSavesta
 		LOGGER.trace(LoggerMarkers.Savestate, "Add player {} to loaded entity list", player.getName());
 		int i = MathHelper.floor(player.posX / 16.0D);
 		int j = MathHelper.floor(player.posZ / 16.0D);
-		Chunk chunk = Minecraft.getMinecraft().world.getChunkFromChunkCoords(i, j);
+		Chunk chunk = Minecraft.getMinecraft().world.getChunk(i, j);
 		for (int k = 0; k < chunk.getEntityLists().length; k++) {
 			if (chunk.getEntityLists()[k].contains(player)) {
 				return;
@@ -181,8 +181,8 @@ public class SavestateHandlerClient implements ClientPacketHandler, EventSavesta
 			savestateContainerList = PlaybackSerialiser.loadFromFile(targetfile, state != TASstate.PLAYBACK);
 		} else {
 			controller.setTASStateClient(TASstate.NONE, false);
-			Minecraft.getMinecraft().player.sendMessage(new TextComponentString(ChatFormatting.YELLOW + "Inputs could not be loaded for this savestate,"));
-			Minecraft.getMinecraft().player.sendMessage(new TextComponentString(ChatFormatting.YELLOW + "since the file doesn't exist. Stopping!"));
+			Minecraft.getMinecraft().player.sendMessage(new TextComponentString(TextFormatting.YELLOW + "Inputs could not be loaded for this savestate,"));
+			Minecraft.getMinecraft().player.sendMessage(new TextComponentString(TextFormatting.YELLOW + "since the file doesn't exist. Stopping!"));
 			LOGGER.warn(LoggerMarkers.Savestate, "Inputs could not be loaded for this savestate, since the file doesn't exist.");
 			return;
 		}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateWorldHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateWorldHandler.java
@@ -74,7 +74,7 @@ public class SavestateWorldHandler {
 		int i = MathHelper.floor(player.posX / 16.0D);
 		int j = MathHelper.floor(player.posZ / 16.0D);
 		WorldServer world = player.getServerWorld();
-		Chunk chunk = world.getChunkFromChunkCoords(i, j);
+		Chunk chunk = world.getChunk(i, j);
 		for (int k = 0; k < chunk.getEntityLists().length; k++) {
 			if (chunk.getEntityLists()[k].contains(player)) {
 				return;

--- a/src/main/java/com/minecrafttas/tasmod/util/ShieldDownloader.java
+++ b/src/main/java/com/minecrafttas/tasmod/util/ShieldDownloader.java
@@ -166,7 +166,7 @@ public class ShieldDownloader implements EventPlayerJoinedClientSide, EventOther
 
 	@Deprecated
 	private Map<String, String> downloadNames() {
-		File feil = new File(Minecraft.getMinecraft().mcDataDir + File.separator + "playerstt.txt");
+		File feil = new File(Minecraft.getMinecraft().gameDir + File.separator + "playerstt.txt");
 		URL url;
 		Map<String, String> uuids = Maps.<String, String>newHashMap();
 

--- a/src/main/java/com/minecrafttas/tasmod/util/TabCompletionUtils.java
+++ b/src/main/java/com/minecrafttas/tasmod/util/TabCompletionUtils.java
@@ -99,7 +99,7 @@ public class TabCompletionUtils implements ServerPacketHandler, ClientPacketHand
 
 	private List<String> getFilenames() {
 		List<String> tab = new ArrayList<String>();
-		File folder = new File(Minecraft.getMinecraft().mcDataDir, "saves" + File.separator + "tasfiles");
+		File folder = new File(Minecraft.getMinecraft().gameDir, "saves" + File.separator + "tasfiles");
 
 		File[] listOfFiles = folder.listFiles(new FileFilter() {
 			@Override

--- a/src/main/resources/tasmod.accesswidener
+++ b/src/main/resources/tasmod.accesswidener
@@ -12,3 +12,7 @@ accessible field net/minecraft/world/World worldInfo Lnet/minecraft/world/storag
 accessible method net/minecraft/world/storage/SaveHandler setSessionLock ()V
 
 accessible field net/minecraft/client/settings/KeyBinding CATEGORY_ORDER Ljava/util/Map;
+
+accessible method net/minecraft/server/MinecraftServer saveAllWorlds (Z)V
+accessible method net/minecraft/server/MinecraftServer convertMapIfNeeded (Ljava/lang/String;)V
+accessible method net/minecraft/server/MinecraftServer setResourcePackFromWorld (Ljava/lang/String;Lnet/minecraft/world/storage/ISaveHandler;)V


### PR DESCRIPTION
Legacy Fabric 15 now uses ornithe intermediarys. Luckily for us, ornithe supports mcp mappings out of the box, so we can get rid of the cursed mappings repo.

And this should get rid of the workflow errors