### PR TITLE
[Playback] Fix restartandplay crashing because of temp savestates

### DIFF
--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandPlay.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandPlay.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.savestates.handlers.SavestateTempHandler;
 
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
@@ -41,9 +42,14 @@ public class CommandPlay extends CommandBase {
 		if (!(sender instanceof EntityPlayer)) {
 			return;
 		}
+
+		// Activates temporary savestates, loading one when starting the playback
+		SavestateTempHandler tempSavestateHandler = TASmod.savestateHandlerServer.getSavestateTemporaryHandler();
+		tempSavestateHandler.setActive(true);
+
 		if (args.length <= 1) {
 			boolean noSave = args.length == 1 && "nosave".equals(args[0]);
-			TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setNoSave(noSave);
+			tempSavestateHandler.setActive(!noSave);
 
 			TASmod.playbackControllerServer.togglePlayback();
 		} else if (args.length > 2) {

--- a/src/main/java/com/minecrafttas/tasmod/commands/CommandRecord.java
+++ b/src/main/java/com/minecrafttas/tasmod/commands/CommandRecord.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.savestates.handlers.SavestateTempHandler;
 
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
@@ -41,9 +42,14 @@ public class CommandRecord extends CommandBase {
 		if (!(sender instanceof EntityPlayer)) {
 			return;
 		}
+
+		// Activates temporary savestates, creating one when starting the recording
+		SavestateTempHandler tempSavestateHandler = TASmod.savestateHandlerServer.getSavestateTemporaryHandler();
+		tempSavestateHandler.setActive(true);
+
 		if (args.length <= 1) {
 			boolean noSave = args.length == 1 && "nosave".equals(args[0]);
-			TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setNoSave(noSave);
+			TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setActive(!noSave);
 			TASmod.playbackControllerServer.toggleRecording();
 		} else if (args.length > 1) {
 			sender.sendMessage(new TextComponentString(TextFormatting.RED + "Too many arguments. " + getUsage(sender)));

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -1085,7 +1085,6 @@ public class PlaybackControllerClient implements
 			logger.catching(e);
 		}
 
-		TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setNoSave(true);
 		setTASState(TASstate.PLAYBACK);
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerServer.java
@@ -66,8 +66,12 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 
 		switch (packet) {
 
+			case PLAYBACK_STATE_TEMP_SAVESTATE:
+				if (TASmod.savestateHandlerServer != null)
+					TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setActive(true);
 			case PLAYBACK_STATE:
 				TASstate networkState = TASmodBufferBuilder.readEnum(TASstate.class, buf);
+
 				/* TODO Permissions */
 				setTASState(networkState);
 				break;
@@ -158,7 +162,6 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 				TASmod.savestateHandlerServer.resetState();
 			}
 
-			TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setNoSave(true);
 			setTASStateServer(TASstate.RECORDING);
 
 			try {
@@ -188,7 +191,6 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 				TASmod.savestateHandlerServer.resetState();
 			}
 
-			TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setNoSave(true);
 			setTASStateServer(TASstate.PLAYBACK);
 
 			try {
@@ -200,7 +202,6 @@ public class PlaybackControllerServer implements ServerPacketHandler {
 	}
 
 	public void restartAndPlay(String tasFileName) {
-		TASmod.savestateHandlerServer.getSavestateTemporaryHandler().setNoSave(true);
 		TASmod.playbackControllerServer.setTASStateServer(PLAYBACK);
 
 		TASmod.tickSchedulerServer.add(() -> {

--- a/src/main/java/com/minecrafttas/tasmod/registries/TASmodPackets.java
+++ b/src/main/java/com/minecrafttas/tasmod/registries/TASmodPackets.java
@@ -13,6 +13,7 @@ import com.minecrafttas.tasmod.playback.tasfile.flavor.SerialiserFlavorBase;
 import com.minecrafttas.tasmod.savestates.SavestateHandlerClient;
 import com.minecrafttas.tasmod.savestates.SavestateHandlerServer.SavestateState;
 import com.minecrafttas.tasmod.savestates.gui.GuiSavestate;
+import com.minecrafttas.tasmod.savestates.handlers.SavestateTempHandler;
 import com.minecrafttas.tasmod.savestates.storage.builtin.ClientMotionStorage.MotionData;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerServer.TickratePauseState;
 import com.minecrafttas.tasmod.util.Component;
@@ -230,6 +231,12 @@ public enum TASmodPackets implements PacketID {
 	 * boolean verbose If a chat message should be printed
 	 */
 	PLAYBACK_STATE,
+	/**
+	 * <p>Same as {@link #PLAYBACK_STATE}, but instructs the controller to activate {@link SavestateTempHandler temporary savestates}
+	 * <p>SIDE: Server<br>
+	 * ARGS: See {@link #PLAYBACK_STATE}
+	 */
+	PLAYBACK_STATE_TEMP_SAVESTATE,
 	/**
 	 * <p>Enables/Disables {@link PlaybackFileCommandExtension PlaybackFileCommandExtensions}
 	 * <p>SIDE: Client<br>

--- a/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateTempHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateTempHandler.java
@@ -35,7 +35,7 @@ public class SavestateTempHandler implements EventControllerStateChange, EventRe
 	private final SavestateHandlerServer handler;
 
 	private boolean createState = true;
-	private boolean noSave = false;
+	private boolean active = false;
 
 	public SavestateTempHandler(SavestateHandlerServer handler, Logger logger) {
 		this.logger = logger;
@@ -49,10 +49,10 @@ public class SavestateTempHandler implements EventControllerStateChange, EventRe
 			return;
 		}
 
-		if (noSave) {
-			noSave = false;
+		if (!active) {
 			return;
 		}
+		active = false;
 
 		if (newstate == RECORDING && createState) {
 			logger.info("Creating temporary savestate");
@@ -144,8 +144,8 @@ public class SavestateTempHandler implements EventControllerStateChange, EventRe
 		createState = true;
 	}
 
-	public void setNoSave(boolean noSave) {
-		this.noSave = noSave;
+	public void setActive(boolean active) {
+		this.active = active;
 	}
 
 	@Override


### PR DESCRIPTION
*Found by PoyoSquared*
Restartandplay once again broke for completely unrelated reasons...
This time it was a bad design decision related to temporary savestates...

I needed a way to disable the creation and loading of temp savestates for certain actions... And I decided the best way would be to set the default to be always active and turn it off on other actions...
Now looking at the code again, I realised it would be better to have the default set to off, so I had to negate the logic turning `noSave` into `active` in the code.

This meant there had to be a way for the client to turn on temporary savestates. I decided it would be more descriptive to make a seperate packet that set the tempSavestate handler to active, instead of changing all existing packets... Let's see when my logic breaks...