### PR TITLE
Remove branch limitation from buildandupload

### DIFF
--- a/.github/workflows/buildandupload.yml
+++ b/.github/workflows/buildandupload.yml
@@ -5,8 +5,6 @@ name: Build and Upload to Discord
 
 on:
   push:
-    branches:
-      - develop
     tags-ignore:
       - '**'
 


### PR DESCRIPTION
I want to start using multiple branches and each should be able to upload it's version to the discord server