### PR TITLE
[Savestates] Numerous desync and savestate fixes

### DIFF
--- a/src/main/java/com/minecrafttas/mctcommon/ConfigurationRegistry.java
+++ b/src/main/java/com/minecrafttas/mctcommon/ConfigurationRegistry.java
@@ -49,7 +49,7 @@ public class ConfigurationRegistry extends AbstractRegistry<ConfigOptions> {
 	/**
 	 * <p>Interface for registering your own options in the TASmod config
 	 * 
-	 * @see com.minecrafttas.tasmod.registries.TASmodConfig TASmodConfig 
+	 * @see com.minecrafttas.tasmod.config.TASmodClientConfig TASmodConfig 
 	 * @author Scribble
 	 */
 	public interface ConfigOptions extends Registerable {

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -1,11 +1,14 @@
 package com.minecrafttas.tasmod;
 
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.minecrafttas.mctcommon.CommandRegistry;
+import com.minecrafttas.mctcommon.Configuration;
+import com.minecrafttas.mctcommon.ConfigurationRegistry;
 import com.minecrafttas.mctcommon.events.EventListenerRegistry;
 import com.minecrafttas.mctcommon.events.EventServer.EventServerInit;
 import com.minecrafttas.mctcommon.events.EventServer.EventServerStart;
@@ -24,6 +27,7 @@ import com.minecrafttas.tasmod.commands.CommandRestartAndPlay;
 import com.minecrafttas.tasmod.commands.CommandSaveTAS;
 import com.minecrafttas.tasmod.commands.CommandSavestate;
 import com.minecrafttas.tasmod.commands.CommandTickrate;
+import com.minecrafttas.tasmod.config.TASmodServerConfig;
 import com.minecrafttas.tasmod.handlers.PlayUntilHandler;
 import com.minecrafttas.tasmod.ktrng.GlobalRandomnessTimer;
 import com.minecrafttas.tasmod.ktrng.builtin.MathRandomness;
@@ -101,6 +105,8 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 
 	public static KillTheRNGMonitor debugRand = new KillTheRNGMonitor();
 
+	public static Configuration config;
+
 	@Override
 	public void onInitialize() {
 
@@ -161,6 +167,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 	public void onServerInit(MinecraftServer server) {
 		LOGGER.info("Initializing server");
 		serverInstance = server;
+		loadConfig(server);
 
 		// Command handling
 
@@ -224,5 +231,16 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 
 	public static MinecraftServer getServerInstance() {
 		return serverInstance;
+	}
+
+	private void loadConfig(MinecraftServer server) {
+		Path configDir = server.getDataDirectory().toPath();
+
+		ConfigurationRegistry SERVER_CONFIG_REGISTRY = new ConfigurationRegistry();
+		SERVER_CONFIG_REGISTRY.register(TASmodServerConfig.values());
+		config = new Configuration("TASmod Server Configuration", configDir.resolve("tasmod.cfg"), SERVER_CONFIG_REGISTRY);
+
+		config.load();
+		config.save();
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmodClient.java
@@ -24,6 +24,7 @@ import com.minecrafttas.mctcommon.networking.Client;
 import com.minecrafttas.mctcommon.networking.PacketHandlerRegistry;
 import com.minecrafttas.mctcommon.networking.Server;
 import com.minecrafttas.tasmod.commands.client.CommandFolder;
+import com.minecrafttas.tasmod.config.TASmodClientConfig;
 import com.minecrafttas.tasmod.gui.InfoHud;
 import com.minecrafttas.tasmod.handlers.LoadingScreenHandler;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient;
@@ -36,7 +37,6 @@ import com.minecrafttas.tasmod.playback.metadata.builtin.StartpositionMetadataEx
 import com.minecrafttas.tasmod.playback.tasfile.flavor.builtin.AlphaFlavor;
 import com.minecrafttas.tasmod.playback.tasfile.flavor.builtin.Beta1Flavor;
 import com.minecrafttas.tasmod.registries.TASmodAPIRegistry;
-import com.minecrafttas.tasmod.registries.TASmodConfig;
 import com.minecrafttas.tasmod.registries.TASmodKeybinds;
 import com.minecrafttas.tasmod.registries.TASmodPackets;
 import com.minecrafttas.tasmod.savestates.SavestateHandlerClient;
@@ -294,7 +294,7 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 			int PORT = TASmod.server.port;
 
 			// Get the connection on startup from config
-			String configAddress = config.get(TASmodConfig.ServerConnection);
+			String configAddress = config.get(TASmodClientConfig.ServerConnection);
 			if (configAddress != null && !configAddress.isEmpty()) {
 				String[] ipSplit = configAddress.split(":");
 				IP = ipSplit[0];
@@ -348,10 +348,10 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 		TASmodAPIRegistry.PLAYBACK_FILE_COMMAND.setConfig(config);
 	}
 
-	private static final ConfigurationRegistry CONFIG_REGISTRY = new ConfigurationRegistry();
+	private static final ConfigurationRegistry CLIENT_CONFIG_REGISTRY = new ConfigurationRegistry();
 
 	private void registerConfigValues() {
-		CONFIG_REGISTRY.register(TASmodConfig.values());
+		CLIENT_CONFIG_REGISTRY.register(TASmodClientConfig.values());
 	}
 
 	private void loadConfig(Minecraft mc) {
@@ -363,7 +363,7 @@ public class TASmodClient implements ClientModInitializer, EventClientInit, Even
 				LOGGER.catching(e);
 			}
 		}
-		config = new Configuration("TASmod configuration", configDir.resolve("tasmod.cfg"), CONFIG_REGISTRY);
+		config = new Configuration("TASmod configuration", configDir.resolve("tasmod.cfg"), CLIENT_CONFIG_REGISTRY);
 
 		config.load();
 		config.save();

--- a/src/main/java/com/minecrafttas/tasmod/config/TASmodClientConfig.java
+++ b/src/main/java/com/minecrafttas/tasmod/config/TASmodClientConfig.java
@@ -1,4 +1,4 @@
-package com.minecrafttas.tasmod.registries;
+package com.minecrafttas.tasmod.config;
 
 import com.minecrafttas.mctcommon.ConfigurationRegistry.ConfigOptions;
 
@@ -7,7 +7,7 @@ import com.minecrafttas.mctcommon.ConfigurationRegistry.ConfigOptions;
  * 
  * @author Scribble
  */
-public enum TASmodConfig implements ConfigOptions {
+public enum TASmodClientConfig implements ConfigOptions {
 	FileToOpen("fileToOpen", ""),
 	ServerConnection("serverConnection", ""),
 	EnabledFileCommands("enabledFileCommands", "tasmod_desyncMonitor@v1, tasmod_label@v1, tasmod_options@v1"),
@@ -16,7 +16,7 @@ public enum TASmodConfig implements ConfigOptions {
 	private String configKey;
 	private String defaultValue;
 
-	private TASmodConfig(String configKey, String defaultValue) {
+	private TASmodClientConfig(String configKey, String defaultValue) {
 		this.configKey = configKey;
 		this.defaultValue = defaultValue;
 	}
@@ -33,6 +33,6 @@ public enum TASmodConfig implements ConfigOptions {
 
 	@Override
 	public String getExtensionName() {
-		return "TASmodConfig";
+		return "TASmodClientConfig";
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/config/TASmodServerConfig.java
+++ b/src/main/java/com/minecrafttas/tasmod/config/TASmodServerConfig.java
@@ -1,0 +1,30 @@
+package com.minecrafttas.tasmod.config;
+
+import com.minecrafttas.mctcommon.ConfigurationRegistry.ConfigOptions;
+
+public enum TASmodServerConfig implements ConfigOptions {
+	PauseOnTempSavestate("pauseOnTempSavestate", "false");
+
+	private String configKey;
+	private String defaultValue;
+
+	private TASmodServerConfig(String configKey, String defaultValue) {
+		this.configKey = configKey;
+		this.defaultValue = defaultValue;
+	}
+
+	@Override
+	public String getDefaultValue() {
+		return defaultValue;
+	}
+
+	@Override
+	public String getConfigKey() {
+		return configKey;
+	}
+
+	@Override
+	public String getExtensionName() {
+		return "TASmodClientConfig";
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinRenderLivingBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinRenderLivingBase.java
@@ -30,15 +30,17 @@ public abstract class MixinRenderLivingBase extends Render {
 	@SuppressWarnings("unchecked")
 	@Inject(method = "renderName", at = @At(value = "HEAD"))
 	public void inject_renderName(EntityLivingBase entity, double d, double e, double f, CallbackInfo ci) {
-		Entity serverEntity = TASmod.getServerInstance().getEntityFromUuid(entity.getUniqueID());
-		if (serverEntity == null)
-			return;
-		RandomBase random = (RandomBase) serverEntity.rand;
-		long seed = random.getSeed();
-		long distance = -random.distance(random.getInitialSeed());
-		GlStateManager.alphaFunc(516, 0.1F);
-		this.renderEntityName(entity, d, e + 0.69D, f, Long.toString(random.getInitialSeed()), 64);
-		this.renderEntityName(entity, d, e + 0.46D, f, Long.toString(seed), 64);
-		this.renderEntityName(entity, d, e + 0.23D, f, Long.toString(distance), 64);
+		if (System.getProperty("tasmod.killtherng.entitytrace", "false").equals("true")) {
+			Entity serverEntity = TASmod.getServerInstance().getEntityFromUuid(entity.getUniqueID());
+			if (serverEntity == null)
+				return;
+			RandomBase random = (RandomBase) serverEntity.rand;
+			long seed = random.getSeed();
+			long distance = -random.distance(random.getInitialSeed());
+			GlStateManager.alphaFunc(516, 0.1F);
+			this.renderEntityName(entity, d, e + 0.69D, f, Long.toString(random.getInitialSeed()), 64);
+			this.renderEntityName(entity, d, e + 0.46D, f, Long.toString(seed), 64);
+			this.renderEntityName(entity, d, e + 0.23D, f, Long.toString(distance), 64);
+		}
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/PlaybackControllerClient.java
@@ -34,6 +34,7 @@ import com.minecrafttas.mctcommon.networking.exception.WrongSideException;
 import com.minecrafttas.mctcommon.networking.interfaces.ClientPacketHandler;
 import com.minecrafttas.mctcommon.networking.interfaces.PacketID;
 import com.minecrafttas.tasmod.TASmodClient;
+import com.minecrafttas.tasmod.config.TASmodClientConfig;
 import com.minecrafttas.tasmod.events.EventClient.EventClientTickPost;
 import com.minecrafttas.tasmod.events.EventClient.EventClientTickPre;
 import com.minecrafttas.tasmod.events.EventClient.EventDrawScreen;
@@ -49,7 +50,6 @@ import com.minecrafttas.tasmod.playback.metadata.PlaybackMetadata;
 import com.minecrafttas.tasmod.playback.tasfile.PlaybackSerialiser;
 import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackLoadException;
 import com.minecrafttas.tasmod.playback.tasfile.exception.PlaybackSaveException;
-import com.minecrafttas.tasmod.registries.TASmodConfig;
 import com.minecrafttas.tasmod.registries.TASmodPackets;
 import com.minecrafttas.tasmod.util.DebugWriter;
 import com.minecrafttas.tasmod.util.Ducks.GuiScreenDuck;
@@ -1032,7 +1032,7 @@ public class PlaybackControllerClient implements
 					e.printStackTrace();
 				}
 				Minecraft.getMinecraft().addScheduledTask(() -> {
-					TASmodClient.config.set(TASmodConfig.FileToOpen, tasFilename);
+					TASmodClient.config.set(TASmodClientConfig.FileToOpen, tasFilename);
 					System.exit(0);
 				});
 				break;
@@ -1081,11 +1081,11 @@ public class PlaybackControllerClient implements
 	@Override
 	public void onClientInit(Minecraft mc) {
 		// Execute /restartandplay. Load the file to start from the config. If it exists load the playback file on start.
-		String fileOnStart = TASmodClient.config.get(TASmodConfig.FileToOpen);
+		String fileOnStart = TASmodClient.config.get(TASmodClientConfig.FileToOpen);
 		if (fileOnStart.isEmpty()) {
 			return;
 		} else {
-			TASmodClient.config.reset(TASmodConfig.FileToOpen);
+			TASmodClient.config.reset(TASmodClientConfig.FileToOpen);
 		}
 
 		try {

--- a/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommandsRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/playback/filecommands/PlaybackFileCommandsRegistry.java
@@ -7,12 +7,12 @@ import java.util.List;
 
 import com.minecrafttas.mctcommon.Configuration;
 import com.minecrafttas.mctcommon.registry.AbstractRegistry;
+import com.minecrafttas.tasmod.config.TASmodClientConfig;
 import com.minecrafttas.tasmod.events.EventPlaybackClient;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.InputContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.SortedFileCommandContainer;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.UnsortedFileCommandContainer;
-import com.minecrafttas.tasmod.registries.TASmodConfig;
 
 public class PlaybackFileCommandsRegistry extends AbstractRegistry<PlaybackFileCommandExtension> implements EventPlaybackClient.EventRecordTick, EventPlaybackClient.EventPlaybackTick, EventPlaybackClient.EventRecordClear {
 
@@ -169,7 +169,7 @@ public class PlaybackFileCommandsRegistry extends AbstractRegistry<PlaybackFileC
 		if (config == null) {
 			return;
 		}
-		String enabled = config.get(TASmodConfig.EnabledFileCommands);
+		String enabled = config.get(TASmodClientConfig.EnabledFileCommands);
 		setEnabled(Arrays.asList(enabled.split(", ")));
 	}
 
@@ -182,7 +182,7 @@ public class PlaybackFileCommandsRegistry extends AbstractRegistry<PlaybackFileC
 		enabledExtensions.forEach(element -> {
 			nameList.add(element.getExtensionName());
 		});
-		config.set(TASmodConfig.EnabledFileCommands, String.join(", ", nameList));
+		config.set(TASmodClientConfig.EnabledFileCommands, String.join(", ", nameList));
 		config.save();
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/registries/TASmodKeybinds.java
+++ b/src/main/java/com/minecrafttas/tasmod/registries/TASmodKeybinds.java
@@ -1,7 +1,5 @@
 package com.minecrafttas.tasmod.registries;
 
-import static com.minecrafttas.tasmod.registries.TASmodPackets.PLAYBACK_STATE_TEMP_SAVESTATE;
-
 import org.lwjgl.input.Keyboard;
 
 import com.minecrafttas.mctcommon.KeybindManager.IsKeyDownFunc;
@@ -48,11 +46,11 @@ public enum TASmodKeybinds implements KeybindID {
 		TASmodClient.virtual.CAMERA_ANGLE.updateNextCameraAngle(0, 45);
 	}),
 	TEST1("Various Testing", "TASmod", Keyboard.KEY_F12, () -> {
-		try {
-			TASmodClient.client.send(new TASmodBufferBuilder(PLAYBACK_STATE_TEMP_SAVESTATE).writeEnum(TASstate.RECORDING));
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+		//		try {
+		//			TASmodClient.client.send(new TASmodBufferBuilder(PLAYBACK_STATE_TEMP_SAVESTATE).writeEnum(TASstate.RECORDING));
+		//		} catch (Exception e) {
+		//			e.printStackTrace();
+		//		}
 	}, VirtualKeybindings::isKeyDown),
 	TEST2("Various Testing2", "TASmod", Keyboard.KEY_F7, () -> {
 	}, VirtualKeybindings::isKeyDown);

--- a/src/main/java/com/minecrafttas/tasmod/registries/TASmodPackets.java
+++ b/src/main/java/com/minecrafttas/tasmod/registries/TASmodPackets.java
@@ -6,6 +6,7 @@ import com.minecrafttas.mctcommon.networking.CompactPacketHandler;
 import com.minecrafttas.mctcommon.networking.interfaces.PacketID;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.TASmodClient;
+import com.minecrafttas.tasmod.config.TASmodClientConfig;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient;
 import com.minecrafttas.tasmod.playback.PlaybackControllerClient.TASstate;
 import com.minecrafttas.tasmod.playback.filecommands.PlaybackFileCommand.PlaybackFileCommandExtension;
@@ -67,7 +68,7 @@ public enum TASmodPackets implements PacketID {
 		Keybind tickrate0Kbd = TASmodClient.keybindManager.getKeybind(TASmodKeybinds.TICKRATE_0);
 		String keyName = VirtualKey.getName(tickrate0Kbd.vanillaKeyBinding.getKeyCode());
 
-		if (TASmodClient.config.getBoolean(TASmodConfig.UnpauseWarn))
+		if (TASmodClient.config.getBoolean(TASmodClientConfig.UnpauseWarn))
 			mc.ingameGUI.addChatMessage(ChatType.CHAT, Component.translatable("msg.tasmod.tickrate.tr0warn", Component.literal(keyName).withStyle(TextFormatting.GOLD)).withStyle(TextFormatting.GREEN).build());
 	}),
 	/**

--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerClient.java
@@ -240,7 +240,7 @@ public class SavestateHandlerClient implements ClientPacketHandler, EventSavesta
 			 * <====================>
 			 * */
 			if (controller.size() >= savestateContainerList.size()) {
-				long index = savestateContainerList.size();
+				long index = savestateContainerList.size() - 1;
 
 				preload(controller.getInputs(), index);
 				controller.setIndex(index);

--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
@@ -718,11 +718,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 						resetState();
 					}
 				};
-				if (TASmod.tickratechanger.ticksPerSecond != 0)
-					TASmod.tickSchedulerServer.add(loadstateTask);
-				else
 					TASmod.gameLoopSchedulerServer.add(loadstateTask);
-				break;
 
 			default:
 				throw new PacketNotImplementedException(packet, this.getClass(), Side.SERVER);

--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
@@ -207,8 +207,8 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		SavestateFlags[] flags = new SavestateFlags[] { SavestateFlags.BLOCK_CLIENT_SAVESTATE };
 
 		if (!TASmod.config.getBoolean(TASmodServerConfig.PauseOnTempSavestate)) {
-			flags = Arrays.copyOf(flags, flags.length + 1);
-			flags[flags.length - 1] = SavestateFlags.BLOCK_PAUSE_TICKRATE;
+			if (ArrayUtils.contains(flags, SavestateFlags.BLOCK_PAUSE_TICKRATE))
+				flags = ArrayUtils.add(flags, SavestateFlags.BLOCK_PAUSE_TICKRATE);
 		}
 
 		savestateInner(paths, cb, flags);
@@ -368,8 +368,8 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		SavestateFlags[] flags = new SavestateFlags[] { SavestateFlags.BLOCK_CLIENT_SAVESTATE };
 
 		if (!TASmod.config.getBoolean(TASmodServerConfig.PauseOnTempSavestate)) {
-			flags = Arrays.copyOf(flags, flags.length + 1);
-			flags[flags.length - 1] = SavestateFlags.BLOCK_PAUSE_TICKRATE;
+			if (ArrayUtils.contains(flags, SavestateFlags.BLOCK_PAUSE_TICKRATE))
+				flags = ArrayUtils.add(flags, SavestateFlags.BLOCK_PAUSE_TICKRATE);
 		}
 
 		loadStateInner(paths, cb, flags);
@@ -517,6 +517,8 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 	public void deleteSavestate(int index, SavestateCallback cb) throws SavestateDeleteException {
 		logger.warn(LoggerMarkers.Savestate, "Deleting savestate {}", index);
 		SavestatePaths paths = this.indexer.deleteSavestate(index);
+
+		SavestateIndexer.deleteFolder(paths.getTargetFolder());
 
 		if (cb != null)
 			cb.invoke(paths);
@@ -718,7 +720,7 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 						resetState();
 					}
 				};
-					TASmod.gameLoopSchedulerServer.add(loadstateTask);
+				TASmod.gameLoopSchedulerServer.add(loadstateTask);
 
 			default:
 				throw new PacketNotImplementedException(packet, this.getClass(), Side.SERVER);

--- a/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/SavestateHandlerServer.java
@@ -22,6 +22,7 @@ import com.minecrafttas.mctcommon.networking.interfaces.PacketID;
 import com.minecrafttas.mctcommon.networking.interfaces.ServerPacketHandler;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.commands.CommandSavestate;
+import com.minecrafttas.tasmod.config.TASmodServerConfig;
 import com.minecrafttas.tasmod.events.EventSavestate;
 import com.minecrafttas.tasmod.mixin.savestates.AccessorAnvilChunkLoader;
 import com.minecrafttas.tasmod.mixin.savestates.AccessorChunkLoader;
@@ -202,7 +203,14 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 		state = SavestateState.SAVING;
 
 		SavestatePaths paths = indexer.createTempSavestate();
-		SavestateFlags[] flags = new SavestateFlags[] { SavestateFlags.BLOCK_CLIENT_SAVESTATE, SavestateFlags.BLOCK_PAUSE_TICKRATE };
+
+		SavestateFlags[] flags = new SavestateFlags[] { SavestateFlags.BLOCK_CLIENT_SAVESTATE };
+
+		if (!TASmod.config.getBoolean(TASmodServerConfig.PauseOnTempSavestate)) {
+			flags = Arrays.copyOf(flags, flags.length + 1);
+			flags[flags.length - 1] = SavestateFlags.BLOCK_PAUSE_TICKRATE;
+		}
+
 		savestateInner(paths, cb, flags);
 		paths.getSavestate().save();
 	}
@@ -357,7 +365,13 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 			return;
 
 		// Add blocking flags
-		SavestateFlags[] flags = new SavestateFlags[] { SavestateFlags.BLOCK_CLIENT_SAVESTATE, SavestateFlags.BLOCK_PAUSE_TICKRATE };
+		SavestateFlags[] flags = new SavestateFlags[] { SavestateFlags.BLOCK_CLIENT_SAVESTATE };
+
+		if (!TASmod.config.getBoolean(TASmodServerConfig.PauseOnTempSavestate)) {
+			flags = Arrays.copyOf(flags, flags.length + 1);
+			flags[flags.length - 1] = SavestateFlags.BLOCK_PAUSE_TICKRATE;
+		}
+
 		loadStateInner(paths, cb, flags);
 		/**
 		 * After copying the temporary savestate (which is missing an index in savestate.dat)
@@ -704,7 +718,10 @@ public class SavestateHandlerServer implements ServerPacketHandler {
 						resetState();
 					}
 				};
-				TASmod.gameLoopSchedulerServer.add(loadstateTask);
+				if (TASmod.tickratechanger.ticksPerSecond != 0)
+					TASmod.tickSchedulerServer.add(loadstateTask);
+				else
+					TASmod.gameLoopSchedulerServer.add(loadstateTask);
 				break;
 
 			default:

--- a/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateGuiHandlerClient.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/handlers/SavestateGuiHandlerClient.java
@@ -72,7 +72,7 @@ public class SavestateGuiHandlerClient implements ClientPacketHandler {
 				 * Apparently showing a screen has a tiny influence on the motion of the client...
 				 */
 				mc.displayGuiScreen(null);
-				TASmodClient.tickSchedulerClient.add(() -> {
+				TASmodClient.gameLoopSchedulerClient.add(() -> {
 					displayGuiRename(index);
 				});
 				break;


### PR DESCRIPTION
- Added a server config
- Renamed the current config to client config
- Fixed desync when loading a savestate during playback
- Made savestates less likely to desync immediately after loading
- Add `PauseOnTempSavestate` server config option to enter tickrate 0 after starting a recording/playback
- Fixed `/savestate delete` not deleting the savestate on the file system
- Add VM argument `-Dtasmod.killtherng.entitytrace=true` to enable/disable RNG seeds above the heads of entities