### PR TITLE
[KillTheRNG] Make EntityRNG more robust

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,13 @@ plugins {
 	// loom plugin
 	id "fabric-loom" version "${loom_version}"
 	id "ploceus" version "${loom_version}"
-	id "com.palantir.git-version" version "4.2.0"
-	id "com.diffplug.spotless" version "8.1.0"
+	id "com.diffplug.spotless" version "8.6.0"
 }
 
 // set basic properties
 def hash = ""
 if(project.release=="false") {
-	hash = "-SNAPSHOT_"+versionDetails().gitHash.substring(0,7)
+	hash = "-SNAPSHOT_"+getGitCommitHash()
 }
 version = project.version+hash
 group = project.group
@@ -109,4 +108,22 @@ spotless {
 		eclipse().configFile("formatter/TASmodFormatter.xml")
 	}
 	enforceCheck false
+}
+
+def getGitCommitHash() {
+    def gitFolder = "$projectDir/.git/"
+    def takeFromHash = 7
+    /*
+     * '.git/HEAD' contains either
+     *      in case of detached head: the currently checked out commit hash
+     *      otherwise: a reference to a file containing the current commit hash
+     */
+    def head = new File(gitFolder + "HEAD").text.split(":") // .git/HEAD
+    def isCommit = head.length == 1
+    // def isRef = head.length > 1     // ref: refs/heads/master
+
+    if(isCommit) return head[0].trim().take(takeFromHash) // e5a7c79edabb
+
+    def refHead = new File(gitFolder + head[1].trim()) // .git/refs/heads/master
+    refHead.text.trim().take takeFromHash      
 }

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -41,6 +41,7 @@ import com.minecrafttas.tasmod.savestates.SavestateHandlerServer;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateGuiHandlerServer;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateResourcePackHandler;
 import com.minecrafttas.tasmod.savestates.storage.builtin.ClientMotionStorage;
+import com.minecrafttas.tasmod.savestates.storage.builtin.EntityBatSpawnPositionStorage;
 import com.minecrafttas.tasmod.savestates.storage.builtin.EntityTickTimersStorage;
 import com.minecrafttas.tasmod.savestates.storage.builtin.KTRNGSeedStorage;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerServer;
@@ -100,6 +101,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 
 	public static KTRNGSeedStorage seedStorage = new KTRNGSeedStorage();
 	public static EntityTickTimersStorage entityTickTimers = new EntityTickTimersStorage();
+	public static EntityBatSpawnPositionStorage entityBatSpawnPositionStorage = new EntityBatSpawnPositionStorage();
 
 	public static MathRNG mathRandomness = new MathRNG(0);
 
@@ -232,6 +234,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(motionStorage);
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(seedStorage);
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entityTickTimers);
+		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entityBatSpawnPositionStorage);
 	}
 
 	public static MinecraftServer getServerInstance() {

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -41,6 +41,7 @@ import com.minecrafttas.tasmod.savestates.SavestateHandlerServer;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateGuiHandlerServer;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateResourcePackHandler;
 import com.minecrafttas.tasmod.savestates.storage.builtin.ClientMotionStorage;
+import com.minecrafttas.tasmod.savestates.storage.builtin.EntityTickTimersStorage;
 import com.minecrafttas.tasmod.savestates.storage.builtin.KTRNGSeedStorage;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerServer;
 import com.minecrafttas.tasmod.ticksync.TickSyncServer;
@@ -98,6 +99,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 	public static GlobalRNG globalRandomness;
 
 	public static KTRNGSeedStorage seedStorage = new KTRNGSeedStorage();
+	public static EntityTickTimersStorage entityTickTimers = new EntityTickTimersStorage();
 
 	public static MathRNG mathRandomness = new MathRNG(0);
 
@@ -229,6 +231,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 	private void registerSavestateStorage() {
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(motionStorage);
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(seedStorage);
+		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entityTickTimers);
 	}
 
 	public static MinecraftServer getServerInstance() {

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -33,6 +33,7 @@ import com.minecrafttas.tasmod.ktrng.GlobalRNG;
 import com.minecrafttas.tasmod.ktrng.builtin.MathRNG;
 import com.minecrafttas.tasmod.ktrng.builtin.WorldSeedRNG;
 import com.minecrafttas.tasmod.ktrng.events.KillTheRNGMonitor;
+import com.minecrafttas.tasmod.ktrng.handlers.UUIDHandler;
 import com.minecrafttas.tasmod.playback.PlaybackControllerServer;
 import com.minecrafttas.tasmod.playback.metadata.builtin.StartpositionMetadataExtension;
 import com.minecrafttas.tasmod.registries.TASmodAPIRegistry;
@@ -109,6 +110,8 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 
 	public static KillTheRNGMonitor debugRand = new KillTheRNGMonitor();
 
+	public static UUIDHandler uuidHandler = new UUIDHandler();
+
 	public static Configuration config;
 
 	@Override
@@ -155,6 +158,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 		EventListenerRegistry.register(resourcepackHandler);
 		PacketHandlerRegistry.register(playUntil);
 		EventListenerRegistry.register(playUntil);
+		EventListenerRegistry.register(uuidHandler);
 		EventListenerRegistry.register(TASmodAPIRegistry.SAVESTATE_STORAGE);
 
 		registerSavestateStorage();

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -158,8 +158,10 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 
 	@Override
 	public void onServerStart(MinecraftServer server) {
-		globalRandomness = new GlobalRNG();
-		EventListenerRegistry.register(globalRandomness);
+		if (globalRandomness == null) {
+			globalRandomness = new GlobalRNG();
+			EventListenerRegistry.register(globalRandomness);
+		}
 		mathRandomness = new MathRNG(0);
 	}
 

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -43,6 +43,7 @@ import com.minecrafttas.tasmod.savestates.handlers.SavestateGuiHandlerServer;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateResourcePackHandler;
 import com.minecrafttas.tasmod.savestates.storage.builtin.ClientMotionStorage;
 import com.minecrafttas.tasmod.savestates.storage.builtin.EntityBatSpawnPositionStorage;
+import com.minecrafttas.tasmod.savestates.storage.builtin.EntitySquidRotationStorage;
 import com.minecrafttas.tasmod.savestates.storage.builtin.EntityTickTimersStorage;
 import com.minecrafttas.tasmod.savestates.storage.builtin.KTRNGSeedStorage;
 import com.minecrafttas.tasmod.tickratechanger.TickrateChangerServer;
@@ -103,6 +104,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 	public static KTRNGSeedStorage seedStorage = new KTRNGSeedStorage();
 	public static EntityTickTimersStorage entityTickTimers = new EntityTickTimersStorage();
 	public static EntityBatSpawnPositionStorage entityBatSpawnPositionStorage = new EntityBatSpawnPositionStorage();
+	public static EntitySquidRotationStorage entitySquidRotationStorage = new EntitySquidRotationStorage();
 
 	public static MathRNG mathRandomness = new MathRNG(0);
 
@@ -239,6 +241,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(seedStorage);
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entityTickTimers);
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entityBatSpawnPositionStorage);
+		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entitySquidRotationStorage);
 	}
 
 	public static MinecraftServer getServerInstance() {

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/GlobalRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/GlobalRNG.java
@@ -5,6 +5,13 @@ import com.minecrafttas.mctcommon.events.EventServer;
 import kaptainwutax.seedutils.rand.JRand;
 import net.minecraft.server.MinecraftServer;
 
+/**
+ * <p>Special RNG generating seeds for each new rng instance.
+ * <p>This RNG advances to it's next seed every server tick. Any new RNG created then uses the {@link #currentSeed},<br>
+ * which makes it have a deterministic starting seed
+ * 
+ * @author Scribble
+ */
 public class GlobalRNG implements EventServer.EventServerTick {
 
 	private final JRand globalRNG;

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/RandomBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/RandomBase.java
@@ -31,9 +31,9 @@ public abstract class RandomBase extends Random implements Registerable {
 	@Override
 	public void setSeed(long seedIn) {
 		super.setSeed(seedIn);
-		if (jrand != null)
+		if (jrand != null) {
 			jrand.setSeed(seedIn, false);
-//		super.setSeed(seedIn ^ 0x5deece66dL);
+		}
 	}
 
 	public long getSeed() {
@@ -146,8 +146,8 @@ public abstract class RandomBase extends Random implements Registerable {
 		return Long.toString(getSeed());
 	}
 
-	public void fireSetEvent(String eventType, long seed, String value, int stackTraceOffset) {
-		fireRNGEvent(eventType, seed, value, stackTraceOffset);
+	public void fireSetEvent(String eventType, long seed, String value) {
+//		fireRNGEvent(eventType, seed, value, stackTraceOffset);
 	}
 
 	public void fireGetEvent(String eventType, long seed, String value) {

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/RandomBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/RandomBase.java
@@ -12,9 +12,9 @@ import kaptainwutax.seedutils.rand.JRand;
 
 public abstract class RandomBase extends Random implements Registerable {
 
-	RNGSide side;
-	private long initialSeed;
-	private JRand jrand;
+	protected RNGSide side;
+	protected long initialSeed;
+	protected JRand jrand;
 
 	public RandomBase() {
 		super(TASmod.globalRandomness.getCurrentSeed());

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/RandomBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/RandomBase.java
@@ -10,6 +10,11 @@ import com.minecrafttas.tasmod.events.EventKillTheRNGServer;
 import kaptainwutax.seedutils.lcg.LCG;
 import kaptainwutax.seedutils.rand.JRand;
 
+/**
+ * Base RNG class extending the {@link Random} class, but designed to be easily modifyable and monitorable.
+ * 
+ * @author Scribble
+ */
 public abstract class RandomBase extends Random implements Registerable {
 
 	protected RNGSide side;

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/RandomBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/RandomBase.java
@@ -19,7 +19,7 @@ public abstract class RandomBase extends Random implements Registerable {
 	public RandomBase() {
 		super(TASmod.globalRandomness.getCurrentSeed());
 		initialSeed = TASmod.globalRandomness.getCurrentSeed();
-		jrand = new JRand(initialSeed);
+		jrand = new JRand(initialSeed, false);
 	}
 
 	public RandomBase(long seed) {

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/EntityRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/EntityRNG.java
@@ -14,6 +14,7 @@ public class EntityRNG extends RandomBase {
 
 	@Override
 	public void fireRNGEvent(String eventType, long seed, String value, int stackTraceOffset) {
+		super.fireRNGEvent(eventType, seed, value, stackTraceOffset);
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/EntityRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/EntityRNG.java
@@ -23,7 +23,7 @@ public class EntityRNG extends RandomBase {
 	@Override
 	public void fireRNGEvent(String eventType, long seed, String value, int stackTraceOffset) {
 		String rngType = String.format("%s(%s)", entity.getClass().getSimpleName(), entity.getUniqueID());
-		EventListenerRegistry.fireEvent(EventKillTheRNGServer.EventRNG.class, super.side, eventType, seed, value, rngType, stackTraceOffset);
+		EventListenerRegistry.fireEvent(EventKillTheRNGServer.EventRNG.class, super.side, eventType, seed, value, rngType, 9);
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/EntityRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/EntityRNG.java
@@ -6,6 +6,11 @@ import com.minecrafttas.tasmod.ktrng.RandomBase;
 
 import net.minecraft.entity.Entity;
 
+/**
+ * Custom RNG making {@link Entity#rand} deterministic
+ * 
+ * @author Scribble
+ */
 public class EntityRNG extends RandomBase {
 
 	private Entity entity;

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/EntityRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/EntityRNG.java
@@ -1,20 +1,29 @@
 package com.minecrafttas.tasmod.ktrng.builtin;
 
+import com.minecrafttas.mctcommon.events.EventListenerRegistry;
+import com.minecrafttas.tasmod.events.EventKillTheRNGServer;
 import com.minecrafttas.tasmod.ktrng.RandomBase;
+
+import net.minecraft.entity.Entity;
 
 public class EntityRNG extends RandomBase {
 
-	public EntityRNG() {
+	private Entity entity;
+
+	public EntityRNG(Entity entity) {
 		super();
+		this.entity = entity;
 	}
 
-	public EntityRNG(long seed) {
+	public EntityRNG(long seed, Entity entity) {
 		super(seed);
+		this.entity = entity;
 	}
 
 	@Override
 	public void fireRNGEvent(String eventType, long seed, String value, int stackTraceOffset) {
-		super.fireRNGEvent(eventType, seed, value, stackTraceOffset);
+		String rngType = String.format("%s(%s)", entity.getClass().getSimpleName(), entity.getUniqueID());
+		EventListenerRegistry.fireEvent(EventKillTheRNGServer.EventRNG.class, super.side, eventType, seed, value, rngType, stackTraceOffset);
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/MathRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/MathRNG.java
@@ -18,6 +18,11 @@ public class MathRNG extends RandomBase {
 	}
 
 	@Override
+	public void fireRNGEvent(String eventType, long seed, String value, int stackTraceOffset) {
+//			super.fireRNGEvent(eventType, seed, value, stackTraceOffset);
+	}
+
+	@Override
 	public String getExtensionName() {
 		return "MathRNG";
 	}

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/MathRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/MathRNG.java
@@ -3,7 +3,7 @@ package com.minecrafttas.tasmod.ktrng.builtin;
 import com.minecrafttas.tasmod.ktrng.RandomBase;
 
 /**
- * <p>Randomness instance for hooking into {@link Math#random()}
+ * Custom RNG making {@link Math#random()} deterministic
  * 
  * @author Scribble
  */

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/UUIDRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/UUIDRNG.java
@@ -3,6 +3,13 @@ package com.minecrafttas.tasmod.ktrng.builtin;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.ktrng.RandomBase;
 
+import net.minecraft.entity.Entity;
+
+/**
+ * Custom RNG making {@link Entity#entityUniqueID} deterministic
+ * 
+ * @author Scribble
+ */
 public class UUIDRNG extends RandomBase {
 
 	public static int uuidcounter;
@@ -13,7 +20,6 @@ public class UUIDRNG extends RandomBase {
 
 	@Override
 	public void fireRNGEvent(String eventType, long seed, String value, int stackTraceOffset) {
-		// TODO Auto-generated method stub
 //		super.fireRNGEvent(eventType, seed, value, stackTraceOffset);
 	}
 

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/UUIDRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/UUIDRNG.java
@@ -1,0 +1,25 @@
+package com.minecrafttas.tasmod.ktrng.builtin;
+
+import com.minecrafttas.tasmod.TASmod;
+import com.minecrafttas.tasmod.ktrng.RandomBase;
+
+public class UUIDRNG extends RandomBase {
+
+	public static int uuidcounter;
+
+	public UUIDRNG(int shift) {
+		super(TASmod.globalRandomness.getCurrentSeed() + shift);
+	}
+
+	@Override
+	public void fireRNGEvent(String eventType, long seed, String value, int stackTraceOffset) {
+		// TODO Auto-generated method stub
+//		super.fireRNGEvent(eventType, seed, value, stackTraceOffset);
+	}
+
+	@Override
+	public String getExtensionName() {
+		return "UUIDRNG";
+	}
+
+}

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/WorldRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/WorldRNG.java
@@ -2,6 +2,13 @@ package com.minecrafttas.tasmod.ktrng.builtin;
 
 import com.minecrafttas.tasmod.ktrng.RandomBase;
 
+import net.minecraft.world.World;
+
+/**
+ * Custom RNG making {@link World#rand} deterministic
+ * 
+ * @author Scribble
+ */
 public class WorldRNG extends RandomBase {
 
 	public WorldRNG() {

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/WorldRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/WorldRNG.java
@@ -14,7 +14,7 @@ public class WorldRNG extends RandomBase {
 
 	@Override
 	public void fireRNGEvent(String val, long seed, String value, int offset) {
-		super.fireRNGEvent(val, seed, value, 9);
+//		super.fireRNGEvent(val, seed, value, 9);
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/WorldSeedRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/WorldSeedRNG.java
@@ -2,6 +2,13 @@ package com.minecrafttas.tasmod.ktrng.builtin;
 
 import com.minecrafttas.tasmod.ktrng.RandomBase;
 
+import net.minecraft.world.World;
+
+/**
+ * Custom RNG separating {@link World#setRandomSeed(int, int, int) worldseed setting behaviour} from the normal RNG
+ * 
+ * @author Scribble
+ */
 public class WorldSeedRNG extends RandomBase {
 
 	public WorldSeedRNG() {

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/handlers/KTRNGEntityHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/handlers/KTRNGEntityHandler.java
@@ -24,16 +24,4 @@ public class KTRNGEntityHandler {
 		}
 		return out;
 	}
-
-	public static void setRandomnessList(Map<UUID, EntityRNG> randomnessList) {
-		WorldServer[] worlds = TASmod.getServerInstance().worlds;
-		for (WorldServer worldServer : worlds) {
-			for (Entity entity : worldServer.loadedEntityList) {
-				UUID uuid = entity.getUniqueID();
-				EntityRNG rand = randomnessList.get(uuid);
-				if (rand != null)
-					entity.rand = rand;
-			}
-		}
-	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/handlers/KTRNGEntityHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/handlers/KTRNGEntityHandler.java
@@ -10,6 +10,7 @@ import com.minecrafttas.tasmod.ktrng.builtin.EntityRNG;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.WorldServer;
 
+@Deprecated
 public class KTRNGEntityHandler {
 
 	public static Map<UUID, EntityRNG> getRandomnessList() {

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/handlers/KTRNGWorldHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/handlers/KTRNGWorldHandler.java
@@ -8,6 +8,7 @@ import com.minecrafttas.tasmod.ktrng.builtin.WorldRNG;
 
 import net.minecraft.world.WorldServer;
 
+@Deprecated
 public class KTRNGWorldHandler {
 
 	public static Map<Integer, WorldRNG> getWorldRandomnessMap() {

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/handlers/UUIDHandler.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/handlers/UUIDHandler.java
@@ -1,0 +1,36 @@
+package com.minecrafttas.tasmod.ktrng.handlers;
+
+import java.util.UUID;
+
+import com.minecrafttas.mctcommon.events.EventServer.EventServerTick;
+import com.minecrafttas.tasmod.ktrng.builtin.UUIDRNG;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.MathHelper;
+
+/**
+ * <p>Generates and distributes UUIDs deterministically
+ * <p>This is necessary since the RNG is deterministic and would result in duplicated UUIDs
+ * 
+ * @author Scribble
+ */
+public class UUIDHandler implements EventServerTick {
+
+	private int uuidIndex;
+
+	public UUIDHandler() {
+	}
+
+	@Override
+	public void onServerTick(MinecraftServer server) {
+		uuidIndex = -1;
+	}
+
+	public UUIDRNG getNewUUIDRNG() {
+		return new UUIDRNG(uuidIndex++);
+	}
+
+	public UUID getNewUUID() {
+		return MathHelper.getRandomUUID(getNewUUIDRNG());
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinEntity.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinEntity.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.ktrng.builtin.EntityRNG;
 
 import net.minecraft.entity.Entity;
@@ -20,13 +21,16 @@ public class MixinEntity {
 	@ModifyExpressionValue(method = "<init>", at = @At(value = "NEW", target = "Ljava/util/Random;"))
 	public Random modify_entityRandom(Random original, World world) {
 		if (!world.isRemote) {
-			return new EntityRNG();
+			return new EntityRNG((Entity) (Object) this);
 		}
 		return original;
 	}
 
 	@WrapOperation(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;getRandomUUID(Ljava/util/Random;)Ljava/util/UUID;"))
-	private UUID wrap_getRandomUUID(Random rand, Operation<UUID> original) {
+	private UUID wrap_getRandomUUID(Random rand, Operation<UUID> original, World world) {
+//		return original.call(TASmod.uuidHandler.getNewUUID());
+		if (!world.isRemote)
+			return TASmod.uuidHandler.getNewUUID();
 		return original.call(new Random());
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinEntitySquid.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinEntitySquid.java
@@ -6,7 +6,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
-import com.minecrafttas.tasmod.TASmod;
 
 import net.minecraft.entity.passive.EntitySquid;
 
@@ -15,10 +14,6 @@ public class MixinEntitySquid {
 
 	@WrapWithCondition(method = "<init>", at = @At(value = "INVOKE", target = "Ljava/util/Random;setSeed(J)V"))
 	public boolean remove_setSeed(Random rand, long seed) {
-		Random squidRandom = new Random(seed);
-		if (squidRandom.nextInt(50) == 0) {
-			TASmod.LOGGER.error("SQUIDS ARE EVIL");
-		}
 		return false;
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinEntitySquid.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinEntitySquid.java
@@ -1,0 +1,24 @@
+package com.minecrafttas.tasmod.mixin.killtherng;
+
+import java.util.Random;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.minecrafttas.tasmod.TASmod;
+
+import net.minecraft.entity.passive.EntitySquid;
+
+@Mixin(EntitySquid.class)
+public class MixinEntitySquid {
+
+	@WrapWithCondition(method = "<init>", at = @At(value = "INVOKE", target = "Ljava/util/Random;setSeed(J)V"))
+	public boolean remove_setSeed(Random rand, long seed) {
+		Random squidRandom = new Random(seed);
+		if (squidRandom.nextInt(50) == 0) {
+			TASmod.LOGGER.error("SQUIDS ARE EVIL");
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinRenderLivingBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinRenderLivingBase.java
@@ -41,6 +41,7 @@ public abstract class MixinRenderLivingBase extends Render {
 			this.renderEntityName(entity, d, e + 0.69D, f, Long.toString(random.getInitialSeed()), 64);
 			this.renderEntityName(entity, d, e + 0.46D, f, Long.toString(seed), 64);
 			this.renderEntityName(entity, d, e + 0.23D, f, Long.toString(distance), 64);
+			this.renderEntityName(entity, d, e, f, entity.getUniqueID().toString(), 64);
 		}
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinWorld.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinWorld.java
@@ -1,6 +1,8 @@
 package com.minecrafttas.tasmod.mixin.killtherng;
 
+import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -8,9 +10,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.ModifyReceiver;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.minecrafttas.tasmod.TASmod;
 import com.minecrafttas.tasmod.ktrng.builtin.WorldRNG;
+import com.minecrafttas.tasmod.util.SortedList;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 
@@ -33,5 +39,20 @@ public class MixinWorld {
 	@ModifyReturnValue(method = "setRandomSeed", at = @At(value = "RETURN"))
 	public Random modify_worldSetRNGReturn(Random original) {
 		return TASmod.worldSeedRandomness;
+	}
+
+	@WrapOperation(method = "<init>", at = @At(value = "FIELD", target = "Lnet/minecraft/world/World;loadedEntityList:Ljava/util/List;"))
+	private <E> void modify_loadedEntityList(World owner, List<E> list, Operation<Void> operation) {
+		operation.call(owner, new SortedList<Entity>((entity, entity2) -> {
+			if (entity == null || entity2 == null)
+				return 0;
+
+			UUID uuid = entity.getUniqueID();
+			UUID uuid2 = entity.getUniqueID();
+
+			if (uuid == null || uuid2 == null)
+				return 0;
+			return uuid.toString().compareTo(uuid2.toString());
+		}));
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinWorld.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinWorld.java
@@ -52,7 +52,7 @@ public class MixinWorld {
 
 			if (uuid == null || uuid2 == null)
 				return 0;
-			return uuid.toString().compareTo(uuid2.toString());
+			return uuid.compareTo(uuid2);
 		}));
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinWorldServer.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinWorldServer.java
@@ -9,10 +9,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
-import com.minecrafttas.mctcommon.events.EventListenerRegistry;
-import com.minecrafttas.tasmod.TASmod;
-import com.minecrafttas.tasmod.events.EventKillTheRNGServer;
-import com.minecrafttas.tasmod.ktrng.RandomBase.RNGSide;
 
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.Chunk;
@@ -22,12 +18,12 @@ public class MixinWorldServer {
 
 	@Inject(method = "updateBlocks", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;enqueueRelightChecks()V"))
 	private void modify_extendedBlockStorage(CallbackInfo ci, @Local Chunk chunk) {
-		TASmod.debugRand.writeDebug(String.format("(%s, %s)", chunk.x, chunk.z));
+//		TASmod.debugRand.writeDebug(String.format("(%s, %s)", chunk.x, chunk.z));
 	}
 
 	@WrapOperation(method = "updateBlocks", at = @At(value = "FIELD", target = "Lnet/minecraft/world/WorldServer;updateLCG:I", opcode = Opcodes.PUTFIELD))
 	private void modify_updateLCG(WorldServer world, int original, Operation<Void> operation) {
-		EventListenerRegistry.fireEvent(EventKillTheRNGServer.EventRNG.class, RNGSide.Server, String.format("updateLCG"), (long) world.updateLCG, Integer.toString(original), "UpdateLCG", 7);
+//		EventListenerRegistry.fireEvent(EventKillTheRNGServer.EventRNG.class, RNGSide.Server, String.format("updateLCG"), (long) world.updateLCG, Integer.toString(original), "UpdateLCG", 7);
 		operation.call(world, original);
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/mixin/savestates/MixinPlayerChunkMap.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/savestates/MixinPlayerChunkMap.java
@@ -15,7 +15,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateWorldHandler;
 import com.minecrafttas.tasmod.util.Ducks.PlayerChunkMapDuck;
-import com.minecrafttas.tasmod.util.SortedArrayList;
+import com.minecrafttas.tasmod.util.SortedList;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.management.PlayerChunkMap;
@@ -54,11 +54,11 @@ public abstract class MixinPlayerChunkMap implements PlayerChunkMapDuck {
 	}
 
 	/**
-	 * Replaces the type of PlayerChunkMap.entries with a {@link SortedArrayList}
+	 * Replaces the type of PlayerChunkMap.entries with a {@link SortedList}
 	 */
 	@WrapOperation(method = "<init>", at = @At(value = "FIELD", target = "Lnet/minecraft/server/management/PlayerChunkMap;entries:Ljava/util/List;"))
 	private <E> void modify_entries(PlayerChunkMap owner, List<E> list, Operation<Void> operation) {
-		operation.call(owner, new SortedArrayList<PlayerChunkMapEntry>((playerChunkMapEntry, playerChunkMapEntry2) -> {
+		operation.call(owner, new SortedList<PlayerChunkMapEntry>((playerChunkMapEntry, playerChunkMapEntry2) -> {
 			if (playerChunkMapEntry == null || playerChunkMapEntry == null)
 				return 0;
 

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityBatSpawnPositionStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityBatSpawnPositionStorage.java
@@ -1,0 +1,59 @@
+package com.minecrafttas.tasmod.savestates.storage.builtin;
+
+import java.util.UUID;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.minecrafttas.tasmod.savestates.storage.SavestateStorageExtensionBase;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.EntityBat;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldServer;
+
+public class EntityBatSpawnPositionStorage extends SavestateStorageExtensionBase {
+
+	public EntityBatSpawnPositionStorage() {
+		super("entityBatSpawnPosition.json");
+	}
+
+	@Override
+	public String getExtensionName() {
+		return "EntityBatSpawnPosition";
+	}
+
+	@Override
+	public JsonObject onSavestate(MinecraftServer server, JsonObject dataToSave) {
+		for (WorldServer worldServer : server.worlds) {
+			for (Entity entity : worldServer.loadedEntityList) {
+				if (entity instanceof EntityBat) {
+					EntityBat bat = (EntityBat) entity;
+					BlockPos spawnPos = bat.spawnPosition;
+					if (spawnPos == null)
+						continue;
+					UUID entityUUID = entity.getUniqueID();
+					dataToSave.addProperty(entityUUID.toString(), Long.toString(bat.spawnPosition.toLong()));
+				}
+			}
+		}
+		return dataToSave;
+	}
+
+	@Override
+	public void onLoadstatePost(MinecraftServer server, JsonObject loadedData) {
+		for (WorldServer worldServer : server.worlds) {
+			for (Entity entity : worldServer.loadedEntityList) {
+				if (entity instanceof EntityBat) {
+					EntityBat bat = (EntityBat) entity;
+					UUID entityUUID = entity.getUniqueID();
+					JsonElement element = loadedData.get(entityUUID.toString());
+					if (element == null)
+						continue;
+					BlockPos spawnPos = BlockPos.fromLong(element.getAsLong());
+					bat.spawnPosition = spawnPos;
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityBatSpawnPositionStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityBatSpawnPositionStorage.java
@@ -42,6 +42,8 @@ public class EntityBatSpawnPositionStorage extends SavestateStorageExtensionBase
 
 	@Override
 	public void onLoadstatePost(MinecraftServer server, JsonObject loadedData) {
+		if (loadedData == null)
+			return;
 		for (WorldServer worldServer : server.worlds) {
 			for (Entity entity : worldServer.loadedEntityList) {
 				if (entity instanceof EntityBat) {

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntitySquidRotationStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntitySquidRotationStorage.java
@@ -1,0 +1,65 @@
+package com.minecrafttas.tasmod.savestates.storage.builtin;
+
+import java.util.UUID;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.minecrafttas.tasmod.savestates.storage.SavestateStorageExtensionBase;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.EntitySquid;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
+
+/**
+ * <p>Stores squid rotation in the savestates
+ * <p>Did you know that the rotation of the squid can trigger an RNG call? Did you know Minecraft does not save this by default?<br>
+ * Well now you know and it's annoying.
+ * 
+ * @author Scribble
+ */
+public class EntitySquidRotationStorage extends SavestateStorageExtensionBase {
+
+	public EntitySquidRotationStorage() {
+		super("entitySquidRotation.json");
+	}
+
+	@Override
+	public String getExtensionName() {
+		return "EntitySquidRotation";
+	}
+
+	@Override
+	public JsonObject onSavestate(MinecraftServer server, JsonObject dataToSave) {
+		for (WorldServer worldServer : server.worlds) {
+			for (Entity entity : worldServer.loadedEntityList) {
+				if (entity instanceof EntitySquid) {
+					EntitySquid squid = (EntitySquid) entity;
+					float rotation = squid.squidRotation;
+					UUID entityUUID = entity.getUniqueID();
+					dataToSave.addProperty(entityUUID.toString(), Float.toString(rotation));
+				}
+			}
+		}
+		return dataToSave;
+	}
+
+	@Override
+	public void onLoadstatePost(MinecraftServer server, JsonObject loadedData) {
+		if (loadedData == null)
+			return;
+		for (WorldServer worldServer : server.worlds) {
+			for (Entity entity : worldServer.loadedEntityList) {
+				if (entity instanceof EntitySquid) {
+					EntitySquid squid = (EntitySquid) entity;
+					UUID entityUUID = entity.getUniqueID();
+					JsonElement element = loadedData.get(entityUUID.toString());
+					if (element == null)
+						continue;
+					float rotation = element.getAsFloat();
+					squid.squidRotation = rotation;
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityTickTimersStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityTickTimersStorage.java
@@ -55,9 +55,12 @@ public class EntityTickTimersStorage extends SavestateStorageExtensionBase {
 
 	@Override
 	public void onLoadstatePost(MinecraftServer server, JsonObject loadedData) {
+		if (loadedData == null)
+			return;
 		for (WorldServer worldServer : server.worlds) {
 			for (Entity entity : worldServer.loadedEntityList) {
 				UUID entityUUID = entity.getUniqueID();
+
 				JsonElement tickCountElement = loadedData.get(entityUUID.toString());
 				if (tickCountElement == null)
 					continue;

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityTickTimersStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityTickTimersStorage.java
@@ -1,0 +1,81 @@
+package com.minecrafttas.tasmod.savestates.storage.builtin;
+
+import java.util.UUID;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.minecrafttas.tasmod.savestates.storage.SavestateStorageExtensionBase;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.ai.EntityAITasks;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
+
+/**
+ * Stores the {@link EntityAITasks#tickCount} in a savestate.
+ * 
+ * AI tasks are only updated every third tick and the tickCount keeps track of that.
+ * 
+ * @author Scribble
+ */
+public class EntityTickTimersStorage extends SavestateStorageExtensionBase {
+
+	public EntityTickTimersStorage() {
+		super("entityTickTimers.json");
+	}
+
+	@Override
+	public String getExtensionName() {
+		return "EntityTickTimers";
+	}
+
+	@Override
+	public JsonObject onSavestate(MinecraftServer server, JsonObject dataToSave) {
+		for (WorldServer worldServer : server.worlds) {
+			for (Entity entity : worldServer.loadedEntityList) {
+				if (entity instanceof EntityLiving) {
+					UUID entityUUID = entity.getUniqueID();
+					EntityLiving entityLiving = (EntityLiving) entity;
+					EntityAITasks tasks = entityLiving.tasks;
+					EntityAITasks targetTasks = entityLiving.targetTasks;
+					int tickCount = tasks.tickCount;
+					int tickCountTarget = targetTasks.tickCount;
+					int tickCountSound = entityLiving.livingSoundTime;
+					JsonObject tickCountList = new JsonObject();
+					tickCountList.addProperty("aitasks", tickCount);
+					tickCountList.addProperty("aitargetTasks", tickCountTarget);
+					tickCountList.addProperty("livingSoundTime", tickCountSound);
+					dataToSave.add(entityUUID.toString(), tickCountList);
+				}
+			}
+		}
+		return dataToSave;
+	}
+
+	@Override
+	public void onLoadstatePost(MinecraftServer server, JsonObject loadedData) {
+		for (WorldServer worldServer : server.worlds) {
+			for (Entity entity : worldServer.loadedEntityList) {
+				UUID entityUUID = entity.getUniqueID();
+				JsonElement tickCountElement = loadedData.get(entityUUID.toString());
+				if (tickCountElement == null)
+					continue;
+				JsonObject tickCountList = tickCountElement.getAsJsonObject();
+
+				int tickCount = tickCountList.get("aitasks").getAsInt();
+				int tickCountTarget = tickCountList.get("aitargetTasks").getAsInt();
+				int tickCountSound = tickCountList.get("livingSoundTime").getAsInt();
+
+				if (entity instanceof EntityLiving) {
+					EntityLiving entityLiving = (EntityLiving) entity;
+					EntityAITasks tasks = entityLiving.tasks;
+					EntityAITasks targetTasks = entityLiving.targetTasks;
+					tasks.tickCount = tickCount;
+					targetTasks.tickCount = tickCountTarget;
+					entityLiving.livingSoundTime = tickCountSound;
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityTickTimersStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityTickTimersStorage.java
@@ -8,6 +8,7 @@ import com.minecrafttas.tasmod.savestates.storage.SavestateStorageExtensionBase;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAITasks;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.WorldServer;
@@ -37,15 +38,18 @@ public class EntityTickTimersStorage extends SavestateStorageExtensionBase {
 				if (entity instanceof EntityLiving) {
 					UUID entityUUID = entity.getUniqueID();
 					EntityLiving entityLiving = (EntityLiving) entity;
+					EntityLivingBase entityLivingBase = (EntityLivingBase) entity;
 					EntityAITasks tasks = entityLiving.tasks;
 					EntityAITasks targetTasks = entityLiving.targetTasks;
 					int tickCount = tasks.tickCount;
 					int tickCountTarget = targetTasks.tickCount;
 					int tickCountSound = entityLiving.livingSoundTime;
+					int tickIdle = entityLivingBase.idleTime;
 					JsonObject tickCountList = new JsonObject();
 					tickCountList.addProperty("aitasks", tickCount);
 					tickCountList.addProperty("aitargetTasks", tickCountTarget);
 					tickCountList.addProperty("livingSoundTime", tickCountSound);
+					tickCountList.addProperty("idleTime", tickIdle);
 					dataToSave.add(entityUUID.toString(), tickCountList);
 				}
 			}
@@ -69,14 +73,17 @@ public class EntityTickTimersStorage extends SavestateStorageExtensionBase {
 				int tickCount = tickCountList.get("aitasks").getAsInt();
 				int tickCountTarget = tickCountList.get("aitargetTasks").getAsInt();
 				int tickCountSound = tickCountList.get("livingSoundTime").getAsInt();
+				int tickCountIdle = tickCountList.get("idleTime").getAsInt();
 
 				if (entity instanceof EntityLiving) {
 					EntityLiving entityLiving = (EntityLiving) entity;
+					EntityLivingBase entityLivingBase = (EntityLivingBase) entity;
 					EntityAITasks tasks = entityLiving.tasks;
 					EntityAITasks targetTasks = entityLiving.targetTasks;
 					tasks.tickCount = tickCount;
 					targetTasks.tickCount = tickCountTarget;
 					entityLiving.livingSoundTime = tickCountSound;
+					entityLivingBase.idleTime = tickCountIdle;
 				}
 			}
 		}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/KTRNGSeedStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/KTRNGSeedStorage.java
@@ -14,7 +14,9 @@ import com.minecrafttas.tasmod.ktrng.handlers.KTRNGEntityHandler;
 import com.minecrafttas.tasmod.ktrng.handlers.KTRNGWorldHandler;
 import com.minecrafttas.tasmod.savestates.storage.SavestateStorageExtensionBase;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
 
 public class KTRNGSeedStorage extends SavestateStorageExtensionBase {
 
@@ -74,15 +76,18 @@ public class KTRNGSeedStorage extends SavestateStorageExtensionBase {
 
 		JsonObject entityRandomListJson = entityRandomDataJson.get("entityList").getAsJsonObject();
 
-		Map<UUID, EntityRNG> randomList = new HashMap<>();
 		for (Entry<String, JsonElement> entry : entityRandomListJson.entrySet()) {
+			WorldServer[] worlds = TASmod.getServerInstance().worlds;
 			UUID uuid = UUID.fromString(entry.getKey().toString());
-			EntityRNG entityRandomness = new EntityRNG(entry.getValue().getAsLong());
+			for (WorldServer worldServer : worlds) {
+				Entity entity = worldServer.getEntityFromUuid(uuid);
+				if (entity == null)
+					continue;
+				EntityRNG entityRandomness = new EntityRNG(entry.getValue().getAsLong(), entity);
+				entity.rand = entityRandomness;
+			}
 
-			randomList.put(uuid, entityRandomness);
 		}
-
-		KTRNGEntityHandler.setRandomnessList(randomList);
 
 		JsonObject worldRandomJson = loadedData.get("worldRandom").getAsJsonObject();
 		JsonObject worldListJson = worldRandomJson.get("worldList").getAsJsonObject();

--- a/src/main/java/com/minecrafttas/tasmod/util/SortedList.java
+++ b/src/main/java/com/minecrafttas/tasmod/util/SortedList.java
@@ -1,30 +1,34 @@
 package com.minecrafttas.tasmod.util;
 
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.ListIterator;
 
 /**
  * Sorts the ArrayList every time an element is added/removed.
  * @param <E> Type The type of the ArrayList
  * @author Scribble
  */
-public class SortedArrayList<E> extends ArrayList<E> {
+public class SortedList<E> extends LinkedList<E> {
 
 	private final Comparator<E> comparable;
 
-	public SortedArrayList(Comparator<E> comparable) {
+	public SortedList(Comparator<E> comparable) {
 		this.comparable = comparable;
 	}
 
 	@Override
 	public boolean add(E newElement) {
-		for (int i = 0; i < this.size(); i++) {
-			E element = this.get(i);
+		ListIterator<E> iterator = (ListIterator<E>) iterator();
+		while (iterator.hasNext()) {
+			E element = iterator.next();
 			if (comparable.compare(element, newElement) >= 0) {
-				super.add(i, newElement);
+				iterator.set(newElement);
+				iterator.add(element);
 				return true;
 			}
 		}
-		return super.add(newElement);
+		super.add(newElement);
+		return true;
 	}
 }

--- a/src/main/resources/tasmod.accesswidener
+++ b/src/main/resources/tasmod.accesswidener
@@ -32,3 +32,4 @@ accessible field net/minecraft/entity/EntityLiving tasks Lnet/minecraft/entity/a
 accessible field net/minecraft/entity/EntityLiving targetTasks Lnet/minecraft/entity/ai/EntityAITasks;
 accessible field net/minecraft/entity/ai/EntityAITasks tickCount I
 accessible field net/minecraft/entity/passive/EntityBat spawnPosition Lnet/minecraft/util/math/BlockPos;
+accessible field net/minecraft/entity/Entity nextEntityID I

--- a/src/main/resources/tasmod.accesswidener
+++ b/src/main/resources/tasmod.accesswidener
@@ -31,3 +31,4 @@ mutable field net/minecraft/world/World rand Ljava/util/Random;
 accessible field net/minecraft/entity/EntityLiving tasks Lnet/minecraft/entity/ai/EntityAITasks;
 accessible field net/minecraft/entity/EntityLiving targetTasks Lnet/minecraft/entity/ai/EntityAITasks;
 accessible field net/minecraft/entity/ai/EntityAITasks tickCount I
+accessible field net/minecraft/entity/passive/EntityBat spawnPosition Lnet/minecraft/util/math/BlockPos;

--- a/src/main/resources/tasmod.accesswidener
+++ b/src/main/resources/tasmod.accesswidener
@@ -28,4 +28,6 @@ accessible field net/minecraft/client/settings/KeyBinding CATEGORY_ORDER Ljava/u
 accessible field net/minecraft/entity/Entity rand Ljava/util/Random;
 accessible field net/minecraft/world/World updateLCG I
 mutable field net/minecraft/world/World rand Ljava/util/Random;
-
+accessible field net/minecraft/entity/EntityLiving tasks Lnet/minecraft/entity/ai/EntityAITasks;
+accessible field net/minecraft/entity/EntityLiving targetTasks Lnet/minecraft/entity/ai/EntityAITasks;
+accessible field net/minecraft/entity/ai/EntityAITasks tickCount I

--- a/src/main/resources/tasmod.accesswidener
+++ b/src/main/resources/tasmod.accesswidener
@@ -33,3 +33,5 @@ accessible field net/minecraft/entity/EntityLiving targetTasks Lnet/minecraft/en
 accessible field net/minecraft/entity/ai/EntityAITasks tickCount I
 accessible field net/minecraft/entity/passive/EntityBat spawnPosition Lnet/minecraft/util/math/BlockPos;
 accessible field net/minecraft/entity/Entity nextEntityID I
+accessible field net/minecraft/entity/EntityLivingBase idleTime I
+

--- a/src/main/resources/tasmod.mixin.json
+++ b/src/main/resources/tasmod.mixin.json
@@ -24,6 +24,7 @@
 		"fixes.MixinDragonFightManager",
 		
 		"killtherng.MixinEntity",
+		"killtherng.MixinEntitySquid",
 		"killtherng.MixinWorld",
 		"killtherng.MixinWorldServer",
 		"killtherng.mathrand.MixinEntityLivingBase",

--- a/src/test/java/tasmod/util/SortedListTest.java
+++ b/src/test/java/tasmod/util/SortedListTest.java
@@ -1,0 +1,45 @@
+package tasmod.util;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.minecrafttas.tasmod.util.SortedList;
+
+class SortedListTest {
+
+	@Test
+	void testSorting() {
+		SortedList<Integer> actual = new SortedList<>((number, number2) -> {
+			return number.compareTo(number2);
+		});
+
+		List<Integer> expected = new LinkedList<>();
+		expected.add(1);
+		expected.add(2);
+		expected.add(3);
+		expected.add(4);
+		expected.add(5);
+		expected.add(6);
+		expected.add(7);
+		expected.add(8);
+		expected.add(9);
+		expected.add(10);
+
+		actual.add(5);
+		actual.add(4);
+		actual.add(10);
+		actual.add(6);
+		actual.add(1);
+		actual.add(8);
+		actual.add(2);
+		actual.add(7);
+		actual.add(3);
+		actual.add(9);
+
+		assertIterableEquals(expected, actual);
+	}
+}


### PR DESCRIPTION
Some improvements to EntityRNG, although it still desyncs. Reason for that is that the EntityAI is not stored in the savestate and is reset when loading the savestate. This makes recording and playback unpredictable in some cases, but the solution here would be to store 60+ EntityAI variants in the savestates and that is no small feat.

- Fix entities initializing with the wrong seed
- Make UUID handling deterministic
- Remove squids setting their own seed
- Remove palantirs gitversion gradle plugin
- Add several variables to savestates
- Sort entities automatically in the loadedEntityList