### PR TITLE
[Savestates] Store EntityAI in savestates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 	// tasmod dependencies
 	embed "com.dselent:bigarraylist:1.6"
 	embed "com.github.KaptainWutax:SeedUtils:b6a383113c"
-
+	
 	// loom dependencies
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings ploceus.mcpMappings(project.mcp_channel, project.mcp_mcversion, project.mcp_build)

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -43,6 +43,7 @@ import com.minecrafttas.tasmod.savestates.SavestateHandlerServer;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateGuiHandlerServer;
 import com.minecrafttas.tasmod.savestates.handlers.SavestateResourcePackHandler;
 import com.minecrafttas.tasmod.savestates.storage.builtin.ClientMotionStorage;
+import com.minecrafttas.tasmod.savestates.storage.builtin.EntityAiTaskStorage;
 import com.minecrafttas.tasmod.savestates.storage.builtin.EntityBatSpawnPositionStorage;
 import com.minecrafttas.tasmod.savestates.storage.builtin.EntitySquidRotationStorage;
 import com.minecrafttas.tasmod.savestates.storage.builtin.EntityTickTimersStorage;
@@ -106,6 +107,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 	public static EntityTickTimersStorage entityTickTimers = new EntityTickTimersStorage();
 	public static EntityBatSpawnPositionStorage entityBatSpawnPositionStorage = new EntityBatSpawnPositionStorage();
 	public static EntitySquidRotationStorage entitySquidRotationStorage = new EntitySquidRotationStorage();
+	public static EntityAiTaskStorage entityAiTaskStorage = new EntityAiTaskStorage();
 
 	public static MathRNG mathRandomness = new MathRNG(0);
 
@@ -246,6 +248,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entityTickTimers);
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entityBatSpawnPositionStorage);
 		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entitySquidRotationStorage);
+		TASmodAPIRegistry.SAVESTATE_STORAGE.register(entityAiTaskStorage);
 	}
 
 	public static MinecraftServer getServerInstance() {

--- a/src/main/java/com/minecrafttas/tasmod/TASmod.java
+++ b/src/main/java/com/minecrafttas/tasmod/TASmod.java
@@ -31,6 +31,7 @@ import com.minecrafttas.tasmod.config.TASmodServerConfig;
 import com.minecrafttas.tasmod.handlers.PlayUntilHandler;
 import com.minecrafttas.tasmod.ktrng.GlobalRNG;
 import com.minecrafttas.tasmod.ktrng.builtin.MathRNG;
+import com.minecrafttas.tasmod.ktrng.builtin.SquidRNG;
 import com.minecrafttas.tasmod.ktrng.builtin.WorldSeedRNG;
 import com.minecrafttas.tasmod.ktrng.events.KillTheRNGMonitor;
 import com.minecrafttas.tasmod.ktrng.handlers.UUIDHandler;
@@ -110,6 +111,8 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 
 	public static WorldSeedRNG worldSeedRandomness = new WorldSeedRNG(0);
 
+	public static SquidRNG squidRNG = new SquidRNG(0L);
+
 	public static KillTheRNGMonitor debugRand = new KillTheRNGMonitor();
 
 	public static UUIDHandler uuidHandler = new UUIDHandler();
@@ -173,6 +176,7 @@ public class TASmod implements ModInitializer, EventServerStart, EventServerInit
 			EventListenerRegistry.register(globalRandomness);
 		}
 		mathRandomness = new MathRNG(0);
+		squidRNG.setSeed(globalRandomness.getCurrentSeed() + 1000L);
 	}
 
 	@Override

--- a/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/SquidRNG.java
+++ b/src/main/java/com/minecrafttas/tasmod/ktrng/builtin/SquidRNG.java
@@ -1,0 +1,16 @@
+package com.minecrafttas.tasmod.ktrng.builtin;
+
+import com.minecrafttas.tasmod.ktrng.RandomBase;
+
+public class SquidRNG extends RandomBase {
+
+	public SquidRNG(long l) {
+		super(l);
+	}
+
+	@Override
+	public String getExtensionName() {
+		return "SquidRNG";
+	}
+
+}

--- a/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinEntitySquid.java
+++ b/src/main/java/com/minecrafttas/tasmod/mixin/killtherng/MixinEntitySquid.java
@@ -6,6 +6,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.minecrafttas.tasmod.TASmod;
 
 import net.minecraft.entity.passive.EntitySquid;
 
@@ -14,6 +15,9 @@ public class MixinEntitySquid {
 
 	@WrapWithCondition(method = "<init>", at = @At(value = "INVOKE", target = "Ljava/util/Random;setSeed(J)V"))
 	public boolean remove_setSeed(Random rand, long seed) {
+		if (TASmod.squidRNG.nextInt(1000) == 0) {
+			TASmod.LOGGER.error("SQUIDS ARE EVIL!!");
+		}
 		return false;
 	}
 }

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/SavestateStorageExtensionBase.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/SavestateStorageExtensionBase.java
@@ -15,12 +15,17 @@ import net.minecraft.server.MinecraftServer;
 
 public abstract class SavestateStorageExtensionBase implements Registerable {
 	protected final Logger logger = TASmod.LOGGER;
-	protected final Gson json = JsonUtils.getJsonInstance();
+	protected final Gson gsonInstance;
 
 	public final Path fileName;
 
-	public SavestateStorageExtensionBase(String fileName) {
+	public SavestateStorageExtensionBase(String filename) {
+		this(filename, JsonUtils.getGsonInstance());
+	}
+
+	public SavestateStorageExtensionBase(String fileName, Gson gson) {
 		this.fileName = Paths.get(fileName);
+		this.gsonInstance = gson;
 	}
 
 	public abstract JsonObject onSavestate(MinecraftServer server, JsonObject dataToSave);

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/SavestateStorageExtensionRegistry.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/SavestateStorageExtensionRegistry.java
@@ -43,7 +43,7 @@ public class SavestateStorageExtensionRegistry extends AbstractRegistry<Savestat
 			JsonObject dataToSave = storage.onSavestate(server, new JsonObject());
 
 			try {
-				JsonUtils.saveJson(dataPath, dataToSave);
+				JsonUtils.saveJson(dataPath, dataToSave, storage.gsonInstance);
 			} catch (IOException e) {
 				throw new SavestateException(e, "Can't save %s from %s extension", storage.fileName, storage.getExtensionName());
 			}
@@ -71,7 +71,7 @@ public class SavestateStorageExtensionRegistry extends AbstractRegistry<Savestat
 
 			JsonObject loadedData;
 			try {
-				loadedData = JsonUtils.loadJson(dataPath);
+				loadedData = JsonUtils.loadJson(dataPath, storage.gsonInstance);
 			} catch (IOException e) {
 				throw new LoadstateException(e, "Can't load %s in %s extension", storage.fileName, storage.getExtensionName());
 			}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/ClientMotionStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/ClientMotionStorage.java
@@ -74,7 +74,7 @@ public class ClientMotionStorage extends SavestateStorageExtensionBase implement
 				if (player.getName().equals(server.getServerOwner())) {
 					uuid = "singleplayer";
 				}
-				dataToSave.add(uuid, json.toJsonTree(data));
+				dataToSave.add(uuid, gsonInstance.toJsonTree(data));
 
 			} catch (TimeoutException e) {
 				throw new SavestateException(e, "Writing client motion for %s timed out!", player.getName());
@@ -92,7 +92,7 @@ public class ClientMotionStorage extends SavestateStorageExtensionBase implement
 
 		for (Entry<String, JsonElement> motionDataJsonElement : loadedData.entrySet()) {
 			String playerUUID = motionDataJsonElement.getKey();
-			MotionData motionData = json.fromJson(motionDataJsonElement.getValue(), MotionData.class);
+			MotionData motionData = gsonInstance.fromJson(motionDataJsonElement.getValue(), MotionData.class);
 
 			EntityPlayerMP player;
 			if (playerUUID.equals("singleplayer")) {

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityAiTaskStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityAiTaskStorage.java
@@ -1,0 +1,161 @@
+package com.minecrafttas.tasmod.savestates.storage.builtin;
+
+import java.util.LinkedHashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+
+import org.spongepowered.asm.mixin.Unique;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.minecrafttas.tasmod.savestates.storage.SavestateStorageExtensionBase;
+import com.minecrafttas.tasmod.savestates.typeadapters.BlockPosTypeAdapterFactory;
+import com.minecrafttas.tasmod.savestates.typeadapters.EntityClassTypeAdapterFactory;
+import com.minecrafttas.tasmod.savestates.typeadapters.EntityTypeAdapterFactory;
+import com.minecrafttas.tasmod.savestates.typeadapters.ItemTypeAdapter;
+import com.minecrafttas.tasmod.savestates.typeadapters.WorldTypeAdapterFactory;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.ai.EntityAIBase;
+import net.minecraft.entity.ai.EntityAITasks;
+import net.minecraft.entity.ai.EntityAITasks.EntityAITaskEntry;
+import net.minecraft.item.Item;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
+
+public class EntityAiTaskStorage extends SavestateStorageExtensionBase {
+
+	public EntityAiTaskStorage() {
+		//@formatter:off
+		super("entityAi.json", 
+				new GsonBuilder()
+				.setPrettyPrinting()
+				.registerTypeAdapterFactory(
+						new EntityTypeAdapterFactory()
+						)
+				.registerTypeAdapterFactory(
+						new WorldTypeAdapterFactory()
+						)
+				.registerTypeAdapterFactory(
+						new EntityClassTypeAdapterFactory()
+						)
+				.registerTypeAdapterFactory(
+						new BlockPosTypeAdapterFactory()
+						)
+				.registerTypeAdapter(Item.class, new ItemTypeAdapter())
+				.setExclusionStrategies(new ExclusionStrategy() {
+					
+					@Override
+					public boolean shouldSkipField(FieldAttributes f) {
+						return f.getAnnotation(Unique.class) != null;
+					}
+					
+					@Override
+					public boolean shouldSkipClass(Class<?> c) {
+						return false;
+					}
+				})
+				.create());
+		//@formatter:on
+	}
+
+	@Override
+	public String getExtensionName() {
+		return "EntityAI";
+	}
+
+	@Override
+	public JsonObject onSavestate(MinecraftServer server, JsonObject dataToSave) {
+		for (WorldServer worldServer : server.worlds) {
+			for (Entity entity : worldServer.loadedEntityList) {
+				if (!(entity instanceof EntityLiving))
+					continue;
+
+				JsonObject mainObject = new JsonObject();
+				EntityLiving entityLiving = (EntityLiving) entity;
+
+				mainObject.addProperty("type", entity.getClass().getSimpleName());
+
+				EntityAITasks tasks = entityLiving.tasks;
+				mainObject.add("tasks", serialiseAITasks(tasks));
+
+				EntityAITasks targetTasks = entityLiving.targetTasks;
+				mainObject.add("targetTasks", serialiseAITasks(targetTasks));
+
+				dataToSave.add(entity.getUniqueID().toString(), mainObject);
+			}
+		}
+		return dataToSave;
+	}
+
+	private JsonObject serialiseAITasks(EntityAITasks tasks) {
+		JsonObject out = new JsonObject();
+		out.add("taskEntries", serialiseAIEntries(tasks.taskEntries));
+		out.add("executingTaskEntries", serialiseAIEntries(tasks.executingTaskEntries));
+		return out;
+	}
+
+	private JsonArray serialiseAIEntries(Set<EntityAITaskEntry> taskEntries) {
+		JsonArray serialisedEntries = new JsonArray();
+		for (EntityAITasks.EntityAITaskEntry entry : taskEntries) {
+			JsonObject jsonAiTaskEntry = new JsonObject();
+			jsonAiTaskEntry.addProperty("priority", entry.priority);
+			jsonAiTaskEntry.addProperty("using", entry.using);
+			jsonAiTaskEntry.addProperty("class", entry.action.getClass().getName());
+			jsonAiTaskEntry.add("action", gsonInstance.toJsonTree(entry.action));
+			serialisedEntries.add(jsonAiTaskEntry);
+		}
+		return serialisedEntries;
+	}
+
+	@Override
+	public void onLoadstatePost(MinecraftServer server, JsonObject loadedData) {
+		for (Entry<String, JsonElement> elements : loadedData.entrySet()) {
+			for (WorldServer worldServer : server.worlds) {
+				EntityLiving entityLiving = (EntityLiving) worldServer.getEntityFromUuid(UUID.fromString(elements.getKey()));
+				if (entityLiving == null)
+					continue;
+
+				JsonObject mainObject = elements.getValue().getAsJsonObject();
+				deserialiseAITasks(entityLiving.tasks, mainObject.get("tasks").getAsJsonObject());
+				deserialiseAITasks(entityLiving.targetTasks, mainObject.get("targetTasks").getAsJsonObject());
+			}
+		}
+	}
+
+	private void deserialiseAITasks(EntityAITasks tasks, JsonObject jsonTasks) {
+		tasks.taskEntries.clear();
+		tasks.taskEntries.addAll(deserialiseAIEntries(tasks, jsonTasks.get("taskEntries").getAsJsonArray()));
+		tasks.executingTaskEntries.clear();
+		tasks.executingTaskEntries.addAll(deserialiseAIEntries(tasks, jsonTasks.get("executingTaskEntries").getAsJsonArray()));
+	}
+
+	private Set<EntityAITaskEntry> deserialiseAIEntries(EntityAITasks tasks, JsonArray jsonEntries) {
+		Set<EntityAITaskEntry> out = new LinkedHashSet<>();
+		for (JsonElement jsonEntryElement : jsonEntries) {
+			JsonObject jsonEntry = jsonEntryElement.getAsJsonObject();
+			int priority = jsonEntry.get("priority").getAsInt();
+			boolean using = jsonEntry.get("using").getAsBoolean();
+			Class<? extends EntityAIBase> clazz;
+			try {
+				clazz = Class.forName(jsonEntry.get("class").getAsString(), false, getClass().getClassLoader()).asSubclass(EntityAIBase.class);
+			} catch (ClassNotFoundException e) {
+				e.printStackTrace();
+				return out;
+			}
+
+			EntityAIBase action = gsonInstance.fromJson(jsonEntry.get("action"), clazz);
+
+			EntityAITaskEntry entry = tasks.new EntityAITaskEntry(priority, action);
+			entry.using = using;
+			out.add(entry);
+		}
+		return out;
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityAiTaskStorage.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/storage/builtin/EntityAiTaskStorage.java
@@ -22,6 +22,7 @@ import com.minecrafttas.tasmod.savestates.typeadapters.WorldTypeAdapterFactory;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.ai.EntityAITasks;
 import net.minecraft.entity.ai.EntityAITasks.EntityAITaskEntry;
@@ -82,6 +83,9 @@ public class EntityAiTaskStorage extends SavestateStorageExtensionBase {
 
 				mainObject.addProperty("type", entity.getClass().getSimpleName());
 
+				mainObject.add("revengeTarget", gsonInstance.toJsonTree(entityLiving.getRevengeTarget()));
+				mainObject.add("lastAttackedEntity", gsonInstance.toJsonTree(entityLiving.getLastAttackedEntity()));
+
 				EntityAITasks tasks = entityLiving.tasks;
 				mainObject.add("tasks", serialiseAITasks(tasks));
 
@@ -123,6 +127,10 @@ public class EntityAiTaskStorage extends SavestateStorageExtensionBase {
 					continue;
 
 				JsonObject mainObject = elements.getValue().getAsJsonObject();
+
+				entityLiving.setRevengeTarget((EntityLivingBase) gsonInstance.fromJson(mainObject.get("revengeTarget"), Entity.class));
+				entityLiving.setLastAttackedEntity((EntityLivingBase) gsonInstance.fromJson(mainObject.get("lastAttackedEntity"), Entity.class));
+
 				deserialiseAITasks(entityLiving.tasks, mainObject.get("tasks").getAsJsonObject());
 				deserialiseAITasks(entityLiving.targetTasks, mainObject.get("targetTasks").getAsJsonObject());
 			}
@@ -130,10 +138,8 @@ public class EntityAiTaskStorage extends SavestateStorageExtensionBase {
 	}
 
 	private void deserialiseAITasks(EntityAITasks tasks, JsonObject jsonTasks) {
-		tasks.taskEntries.clear();
-		tasks.taskEntries.addAll(deserialiseAIEntries(tasks, jsonTasks.get("taskEntries").getAsJsonArray()));
-		tasks.executingTaskEntries.clear();
-		tasks.executingTaskEntries.addAll(deserialiseAIEntries(tasks, jsonTasks.get("executingTaskEntries").getAsJsonArray()));
+		tasks.taskEntries = deserialiseAIEntries(tasks, jsonTasks.get("taskEntries").getAsJsonArray());
+		tasks.executingTaskEntries = deserialiseAIEntries(tasks, jsonTasks.get("executingTaskEntries").getAsJsonArray());
 	}
 
 	private Set<EntityAITaskEntry> deserialiseAIEntries(EntityAITasks tasks, JsonArray jsonEntries) {

--- a/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/BlockPosTypeAdapterFactory.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/BlockPosTypeAdapterFactory.java
@@ -1,0 +1,41 @@
+package com.minecrafttas.tasmod.savestates.typeadapters;
+
+import java.io.IOException;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import net.minecraft.util.math.BlockPos;
+
+public class BlockPosTypeAdapterFactory implements TypeAdapterFactory {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		Class<T> rawType = (Class<T>) type.getRawType();
+		if (!BlockPos.class.isAssignableFrom(rawType))
+			return null;
+		return new TypeAdapter<T>() {
+			@Override
+			public void write(JsonWriter out, T value) throws IOException {
+				if (value == null) {
+					out.nullValue();
+				}
+
+				BlockPos val = (BlockPos) value;
+				out.value(val.toLong());
+			}
+
+			@Override
+			public T read(JsonReader in) throws IOException {
+				if (!in.hasNext())
+					return null;
+				return (T) BlockPos.fromLong(in.nextLong());
+			}
+		};
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/EntityClassTypeAdapterFactory.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/EntityClassTypeAdapterFactory.java
@@ -1,0 +1,49 @@
+package com.minecrafttas.tasmod.savestates.typeadapters;
+
+import java.io.IOException;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.EntityAnimal;
+
+public class EntityClassTypeAdapterFactory implements TypeAdapterFactory {
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		if (!new TypeToken<Class<? extends EntityAnimal>>() {
+		}.equals(type) && !new TypeToken<Class<? extends Entity>>() {
+		}.equals(type)) {
+			return null;
+		}
+
+		return new TypeAdapter<T>() {
+
+			@Override
+			public void write(JsonWriter out, T value) throws IOException {
+				Class<? extends Entity> clazz = (Class) value;
+				out.value(clazz.getTypeName());
+			}
+
+			@Override
+			public T read(JsonReader in) throws IOException {
+				if (!in.hasNext())
+					return null;
+				String jsonString = in.nextString();
+				Class out = null;
+				try {
+					out = Class.forName(jsonString, false, getClass().getClassLoader()).asSubclass(Entity.class);
+				} catch (ClassNotFoundException e) {
+					e.printStackTrace();
+				}
+				return (T) out;
+			}
+		};
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/EntityTypeAdapterFactory.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/EntityTypeAdapterFactory.java
@@ -1,0 +1,93 @@
+package com.minecrafttas.tasmod.savestates.typeadapters;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.minecrafttas.tasmod.TASmod;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
+
+public class EntityTypeAdapterFactory implements TypeAdapterFactory {
+
+	@SuppressWarnings("unchecked")
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		Class<T> rawType = (Class<T>) type.getRawType();
+		if (!Entity.class.isAssignableFrom(rawType))
+			return null;
+
+		return new TypeAdapter<T>() {
+
+			public void write(JsonWriter out, T value) throws IOException {
+				if (value == null) {
+					out.nullValue();
+				} else {
+					Entity entity = (Entity) rawType.cast(value);
+
+					/*
+					 * Instead of storing the players UUID, we will store the index of the playerlist.
+					 * This is because when sharing savestates, the players UUID will be different and thus crash Minecraft.
+					 * 
+					 * TODO Make an option to map "Player0, Player1" etc. to specific playernames, so that this will be deterministic
+					 */
+					if (entity instanceof EntityPlayer) {
+						MinecraftServer server = TASmod.getServerInstance();
+						int counter = 0;
+						for (EntityPlayerMP player : server.getPlayerList().getPlayers()) {
+							if (player.getUniqueID().equals(entity.getUniqueID())) {
+								out.value("Player" + counter);
+								return;
+							}
+						}
+					}
+
+					out.value(entity.getUniqueID().toString());
+				}
+			}
+
+			public T read(JsonReader reader) throws IOException {
+				if (reader.peek() == JsonToken.NULL) {
+					reader.nextNull();
+					return null;
+				} else {
+					if (TASmod.getServerInstance() == null)
+						return null;
+					MinecraftServer server = TASmod.getServerInstance();
+					String entityString = reader.nextString();
+					Entity entity = null;
+
+					/*
+					 * Instead of storing the players UUID, we will store the index of the playerlist.
+					 * This is because when sharing savestates, the players UUID will be different and thus crash Minecraft.
+					 */
+					Matcher matcher = Pattern.compile("Player(\\d+)").matcher(entityString);
+					if (matcher.find()) {
+						int counter = Integer.parseInt(matcher.group(1));
+						entity = server.getPlayerList().getPlayers().get(counter);
+					} else {
+						UUID uuid = UUID.fromString(entityString);
+						for (WorldServer world : server.worlds) {
+							entity = world.getEntityFromUuid(uuid);
+							if (entity != null)
+								break;
+						}
+					}
+
+					return (T) entity;
+				}
+			}
+		};
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/ItemTypeAdapter.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/ItemTypeAdapter.java
@@ -1,0 +1,25 @@
+package com.minecrafttas.tasmod.savestates.typeadapters;
+
+import java.io.IOException;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import net.minecraft.item.Item;
+
+public class ItemTypeAdapter extends TypeAdapter<Item> {
+
+	@Override
+	public void write(JsonWriter out, Item value) throws IOException {
+		out.value(Item.getIdFromItem(value));
+	}
+
+	@Override
+	public Item read(JsonReader in) throws IOException {
+		if (!in.hasNext())
+			return null;
+		return Item.getItemById(in.nextInt());
+	}
+
+}

--- a/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/WorldTypeAdapterFactory.java
+++ b/src/main/java/com/minecrafttas/tasmod/savestates/typeadapters/WorldTypeAdapterFactory.java
@@ -1,0 +1,72 @@
+package com.minecrafttas.tasmod.savestates.typeadapters;
+
+import java.io.IOException;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.minecrafttas.tasmod.TASmod;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+
+public class WorldTypeAdapterFactory implements TypeAdapterFactory {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		Class<T> rawType = (Class<T>) type.getRawType();
+		if (!World.class.isAssignableFrom(rawType))
+			return null;
+
+		return new TypeAdapter<T>() {
+
+			public void write(JsonWriter out, T value) throws IOException {
+				if (value == null) {
+					out.nullValue();
+				} else {
+					if (TASmod.getServerInstance() == null)
+						return;
+					MinecraftServer server = TASmod.getServerInstance();
+					WorldServer world = (WorldServer) rawType.cast(value);
+
+					Integer index = findIndex(server.worlds, world);
+					if (index == null) {
+						out.nullValue();
+						return;
+					}
+					out.value(index);
+				}
+			}
+
+			private Integer findIndex(WorldServer[] worlds, WorldServer world) {
+				int index = 0;
+				for (World otherWorld : worlds) {
+					if (otherWorld.equals(world))
+						return index;
+					index++;
+				}
+				return null;
+			}
+
+			public T read(JsonReader reader) throws IOException {
+				if (reader.peek() == JsonToken.NULL) {
+					reader.nextNull();
+					return null;
+				} else {
+					if (TASmod.getServerInstance() == null)
+						return null;
+					int worldId = Integer.parseInt(reader.nextString());
+					MinecraftServer server = TASmod.getServerInstance();
+
+					return (T) server.worlds[worldId];
+				}
+			}
+		};
+	}
+}

--- a/src/main/java/com/minecrafttas/tasmod/util/JsonUtils.java
+++ b/src/main/java/com/minecrafttas/tasmod/util/JsonUtils.java
@@ -10,24 +10,24 @@ import com.google.gson.JsonObject;
 
 public class JsonUtils {
 
-	public static Gson getJsonInstance() {
+	public static Gson getGsonInstance() {
 		return new GsonBuilder().setPrettyPrinting().create();
 	}
 
 	public static void saveJson(Path savePath, JsonObject data) throws IOException {
-		saveJson(savePath, data, getJsonInstance());
+		saveJson(savePath, data, getGsonInstance());
 	}
 
-	public static void saveJson(Path savePath, JsonObject data, Gson jsonInstance) throws IOException {
-		String out = jsonInstance.toJson(data);
+	public static void saveJson(Path savePath, JsonObject data, Gson gsonInstance) throws IOException {
+		String out = gsonInstance.toJson(data);
 		Files.write(savePath, out.getBytes());
 	}
 
 	public static JsonObject loadJson(Path loadPath) throws IOException {
-		return loadJson(loadPath, getJsonInstance());
+		return loadJson(loadPath, getGsonInstance());
 	}
 
-	public static JsonObject loadJson(Path loadPath, Gson jsonInstance) throws IOException {
-		return jsonInstance.fromJson(new String(Files.readAllBytes(loadPath)), JsonObject.class);
+	public static JsonObject loadJson(Path loadPath, Gson gsonInstance) throws IOException {
+		return gsonInstance.fromJson(new String(Files.readAllBytes(loadPath)), JsonObject.class);
 	}
 }

--- a/src/main/resources/tasmod.accesswidener
+++ b/src/main/resources/tasmod.accesswidener
@@ -35,3 +35,11 @@ accessible field net/minecraft/entity/passive/EntityBat spawnPosition Lnet/minec
 accessible field net/minecraft/entity/Entity nextEntityID I
 accessible field net/minecraft/entity/EntityLivingBase idleTime I
 
+accessible class net/minecraft/entity/ai/EntityAITasks$EntityAITaskEntry
+
+accessible field net/minecraft/entity/ai/EntityAITasks taskEntries Ljava/util/Set;
+mutable field net/minecraft/entity/ai/EntityAITasks taskEntries Ljava/util/Set;
+
+accessible field net/minecraft/entity/ai/EntityAITasks executingTaskEntries Ljava/util/Set;
+mutable field net/minecraft/entity/ai/EntityAITasks executingTaskEntries Ljava/util/Set;
+


### PR DESCRIPTION
A big problem for TASing in general is the fact that entity AI is not stored in the world files... All entities will reset once a world is loaded, which makes savestates around entities very inaccurate. So much so, that the EntityRNG will desync between savestates.

To fix this, I would need to write custom serialisation for  ~60 different classes, each doing something slightly different...
Not fancying that, so instead I employed the help of everyones least favourite json library gson!